### PR TITLE
codec::Codec: Change `profile()` to return `ProfileIter`

### DIFF
--- a/examples/codec-info.rs
+++ b/examples/codec-info.rs
@@ -13,10 +13,7 @@ fn main() {
 			println!("\t description: {}", codec.description());
 			println!("\t medium: {:?}", codec.medium());
 			println!("\t capabilities: {:?}", codec.capabilities());
-
-			if let Some(profiles) = codec.profiles() {
-				println!("\t profiles: {:?}", profiles.collect::<Vec<_>>());
-			}
+			println!("\t profiles: {:?}", codec.profiles().collect::<Vec<_>>());
 
 			if let Ok(video) = codec.video() {
 				println!("\t rates: {:?}", video.rates().collect::<Vec<_>>());
@@ -40,10 +37,7 @@ fn main() {
 			println!("\t description: {}", codec.description());
 			println!("\t medium: {:?}", codec.medium());
 			println!("\t capabilities: {:?}", codec.capabilities());
-
-			if let Some(profiles) = codec.profiles() {
-				println!("\t profiles: {:?}", profiles.collect::<Vec<_>>());
-			}
+			println!("\t profiles: {:?}", codec.profiles().collect::<Vec<_>>());
 
 			if let Ok(video) = codec.video() {
 				println!("\t rates: {:?}", video.rates().collect::<Vec<_>>());

--- a/src/codec/codec.rs
+++ b/src/codec/codec.rs
@@ -102,14 +102,9 @@ impl<'a> Codec<'a> {
 		}
 	}
 
-	pub fn profiles(&self) -> Option<ProfileIter> {
+	pub fn profiles(&self) -> ProfileIter {
 		unsafe {
-			if (*self.as_ptr()).profiles.is_null() {
-				return None;
-			}
-			else {
-				Some(ProfileIter::new(self.id(), (*self.as_ptr()).profiles))
-			}
+		    ProfileIter::new(self.id(), (*self.as_ptr()).profiles)
 		}
 	}
 }
@@ -132,7 +127,7 @@ impl<'a> Iterator for ProfileIter<'a> {
 
 	fn next(&mut self) -> Option<<Self as Iterator>::Item> {
 		unsafe {
-			if (*self.ptr).profile != FF_PROFILE_UNKNOWN && !(*self.ptr).name.is_null() {
+			if !self.ptr.is_null() && (*self.ptr).profile != FF_PROFILE_UNKNOWN && !(*self.ptr).name.is_null() {
 				let profile = Profile::from((self.id, (*self.ptr).profile));
 				self.ptr    = self.ptr.offset(1);
 


### PR DESCRIPTION
This commit changes the return type of the codec::Codec.profile() method from
`Option<ProfileIter>` to `ProfileIter` as an Iterator inherently deals with
optional values. The changed way also matches the Iteraters in codec::{Video,
Audio}.