### PR TITLE
Audio video frame into

### DIFF
--- a/src/util/frame/audio.rs
+++ b/src/util/frame/audio.rs
@@ -252,6 +252,12 @@ impl Clone for Audio {
 	}
 }
 
+impl From<Frame> for Audio {
+	fn from(frame: Frame) -> Self {
+		Audio(frame)
+	}
+}
+
 pub unsafe trait Sample {
 	fn is_valid(format: format::Sample, channels: u16) -> bool;
 }

--- a/src/util/frame/video.rs
+++ b/src/util/frame/video.rs
@@ -319,6 +319,12 @@ impl Clone for Video {
 	}
 }
 
+impl From<Frame> for Video {
+	fn from(frame: Frame) -> Self {
+		Video(frame)
+	}
+}
+
 pub unsafe trait Component {
 	fn is_valid(format: format::Pixel) -> bool;
 }


### PR DESCRIPTION
This is needed as soon we want to use API functions that only return frames (for example [av_buffersink_get_frame_flags](https://www.ffmpeg.org/doxygen/2.7/group__lavfi__buffersink.html#ga71ae9c529c8da51681e12faa37d1a395)).