### PR TITLE
Best channel layout

### DIFF
--- a/examples/transcode-audio.rs
+++ b/examples/transcode-audio.rs
@@ -53,9 +53,11 @@ fn transcoder<P: AsRef<Path>>(ictx: &mut format::context::Input, octx: &mut form
 	let mut output  = octx.add_stream(&codec);
 	let mut encoder = try!(output.codec().encoder().audio());
 
+	let channel_layout = codec.channel_layouts().map(|iter| iter.best(decoder.channel_layout().channels())).unwrap_or(ffmpeg::channel_layout::STEREO);
+
 	encoder.set_rate(decoder.rate() as i32);
-	encoder.set_channel_layout(decoder.channel_layout());
-	encoder.set_channels(decoder.channel_layout().channels());
+	encoder.set_channel_layout(channel_layout);
+	encoder.set_channels(channel_layout.channels());
 	encoder.set_format(codec.formats().expect("unknown supported formats").next().unwrap());
 
 	output.set_time_base((1, decoder.rate() as i32));

--- a/src/codec/audio.rs
+++ b/src/codec/audio.rs
@@ -121,6 +121,17 @@ impl ChannelLayoutIter {
 	pub fn new(ptr: *const u64) -> Self {
 		ChannelLayoutIter { ptr: ptr }
 	}
+
+	pub fn best(self, maximum: i32) -> ChannelLayout {
+		let cmp = |acc: ChannelLayout, curr: ChannelLayout|
+			if curr.channels() > curr.channels() && curr.channels() <= maximum {
+				curr
+			}
+			else {
+				acc
+			};
+		self.fold(::channel_layout::MONO, cmp)
+    }
 }
 
 impl Iterator for ChannelLayoutIter {


### PR DESCRIPTION
Is some cases the decoder channel layout is not supported by the selected encoder. A selection from the channel layouts supported by the encoder is needed. For this the method `best()` is introduced.
