### PR TITLE
codec/audio: fix `ChannelLayoutIter.best()`

### DIFF
--- a/src/codec/audio.rs
+++ b/src/codec/audio.rs
@@ -124,7 +124,7 @@ impl ChannelLayoutIter {
 
 	pub fn best(self, max: i32) -> ChannelLayout {
 		self.fold(::channel_layout::MONO, |acc, cur|
-			if cur.channels() > cur.channels() && cur.channels() <= max {
+			if cur.channels() > acc.channels() && cur.channels() <= max {
 				cur
 			}
 			else {


### PR DESCRIPTION
Somehow the condition `cur.channels() > cur.channels()` slipped in which will
always be `false`. The correct condition is `cur.channels() > acc.channels()`.