### PR TITLE
Encoder set timebase

### DIFF
--- a/examples/transcode-audio.rs
+++ b/examples/transcode-audio.rs
@@ -62,6 +62,7 @@ fn transcoder<P: AsRef<Path>>(ictx: &mut format::context::Input, octx: &mut form
 	encoder.set_channels(channel_layout.channels());
 	encoder.set_format(codec.formats().expect("unknown supported formats").next().unwrap());
 
+	encoder.set_time_base((1, decoder.rate() as i32));
 	output.set_time_base((1, decoder.rate() as i32));
 
 	let encoder = try!(encoder.open_as(&codec));

--- a/src/codec/encoder/mod.rs
+++ b/src/codec/encoder/mod.rs
@@ -87,6 +87,12 @@ impl Encoder {
 		}
 	}
 
+	pub fn set_time_base<R: Into<Rational>>(&mut self, value: R) {
+		unsafe {
+			(*self.as_mut_ptr()).time_base = value.into().into();
+		}
+	}
+
 	pub fn set_frame_rate<R: Into<Rational>>(&mut self, value: Option<R>) {
 		unsafe {
 			if let Some(value) = value {


### PR DESCRIPTION
The [documentation](https://ffmpeg.org/doxygen/trunk/structAVCodecContext.html#ab7bfeb9fa5840aac090e2b0bd0ef7589) states this as necessary.

And it actually enables encoding to webm.