### PR TITLE
Correct time base handling in `transcode-audio`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: rust
+
+rust:
+  - stable
+  - beta
+  - nightly
+
+addons:
+  apt:
+    packages:
+      - nasm
+
+script:
+  - cargo test --features build

--- a/examples/transcode-audio.rs
+++ b/examples/transcode-audio.rs
@@ -9,9 +9,8 @@ use ffmpeg::option::Settable;
 fn filter(spec: &str, decoder: &codec::decoder::Audio, encoder: &codec::encoder::Audio) -> Result<filter::Graph, ffmpeg::Error> {
 	let mut filter = filter::Graph::new();
 
-	let base = ffmpeg::Rational(1, 1000000);
 	let args = format!("time_base={}:sample_rate={}:sample_fmt={}:channel_layout=0x{:x}",
-		base, decoder.rate(), decoder.format().name(), decoder.channel_layout().bits());
+		decoder.time_base(), decoder.rate(), decoder.format().name(), decoder.channel_layout().bits());
 
 	try!(filter.add(&filter::find("abuffer").unwrap(), "in", &args));
 	try!(filter.add(&filter::find("abuffersink").unwrap(), "out", ""));
@@ -103,7 +102,7 @@ fn main() {
 	octx.set_metadata(ictx.metadata().to_owned());
 	octx.write_header().unwrap();
 
-	let in_time_base  = (1, 1000000);
+	let in_time_base  = transcoder.decoder.time_base();
 	let out_time_base = octx.stream(0).unwrap().time_base();
 
 	let mut decoded = frame::Audio::empty();

--- a/src/codec/decoder/mod.rs
+++ b/src/codec/decoder/mod.rs
@@ -24,7 +24,7 @@ use std::ops::{Deref, DerefMut};
 
 use ffi::*;
 use super::{Id, Context};
-use ::{Codec, Error, Discard, Dictionary};
+use ::{Codec, Error, Discard, Rational, Dictionary};
 
 pub struct Decoder(pub Context);
 
@@ -125,6 +125,12 @@ impl Decoder {
 	pub fn skip_frame(&mut self, value: Discard) {
 		unsafe {
 			(*self.as_mut_ptr()).skip_frame = value.into();
+		}
+	}
+
+	pub fn time_base(&self) -> Rational {
+		unsafe {
+			Rational::from((*self.as_ptr()).time_base)
 		}
 	}
 }


### PR DESCRIPTION
This adapts the time base handling in `transcode-audio` as it is done in the `transcoding.c` example in the ffmpeg `doc/examples` folder.

It also seems to be the necessary way as I had audio/video sync problems with the old way.