### PR TITLE
examples/metadata: fix after `Stream::frame_rate()` -> `Stream::rate(…

### DIFF
--- a/examples/metadata.rs
+++ b/examples/metadata.rs
@@ -31,7 +31,7 @@ fn main() {
 				println!("\tframes: {}", stream.frames());
 				println!("\tdisposition: {:?}", stream.disposition());
 				println!("\tdiscard: {:?}", stream.discard());
-				println!("\tframe_rate: {}", stream.frame_rate());
+				println!("\tstream rate: {}", stream.rate());
 		
 				let codec = stream.codec();
 				println!("\tmedium: {:?}", codec.medium());


### PR DESCRIPTION
…)` rename