### PR TITLE
device/output: fix infinite iterator loop

### DIFF
--- a/src/device/output.rs
+++ b/src/device/output.rs
@@ -17,6 +17,8 @@ impl Iterator for AudioIter {
 				None
 			}
 			else {
+				self.0 = ptr;
+
 				Some(Format::Output(format::Output::wrap(ptr)))
 			}
 		}
@@ -40,6 +42,8 @@ impl Iterator for VideoIter {
 				None
 			}
 			else {
+				self.0 = ptr;
+
 				Some(Format::Output(format::Output::wrap(ptr)))
 			}
 		}


### PR DESCRIPTION
These two iterators were not settings `self.0` and thus weren't advancing to the next device causing an infinite loop.