### PR TITLE
Slices from planes are too long

### DIFF
--- a/src/util/frame/audio.rs
+++ b/src/util/frame/audio.rs
@@ -157,9 +157,7 @@ impl Audio {
 		}
 
 		unsafe {
-			slice::from_raw_parts(
-				mem::transmute((*self.as_ptr()).data[index]),
-				mem::size_of::<T>() * self.samples())
+			slice::from_raw_parts(mem::transmute((*self.as_ptr()).data[index]),self.samples())
 		}
 	}
 
@@ -174,9 +172,7 @@ impl Audio {
 		}
 
 		unsafe {
-			slice::from_raw_parts_mut(
-				mem::transmute((*self.as_mut_ptr()).data[index]),
-				mem::size_of::<T>() * self.samples())
+			slice::from_raw_parts_mut(mem::transmute((*self.as_mut_ptr()).data[index]),self.samples())
 		}
 	}
 


### PR DESCRIPTION
from_raw_parts_mut takes length as the size of the slice in Ts, not in u8s