### PR TITLE
format/format: make `description()` to return `long_name`

### DIFF
--- a/src/format/format/input.rs
+++ b/src/format/format/input.rs
@@ -30,7 +30,7 @@ impl Input {
 
 	pub fn description(&self) -> &str {
 		unsafe {
-			from_utf8_unchecked(CStr::from_ptr((*self.as_ptr()).name).to_bytes())
+			from_utf8_unchecked(CStr::from_ptr((*self.as_ptr()).long_name).to_bytes())
 		}
 	}
 

--- a/src/format/format/output.rs
+++ b/src/format/format/output.rs
@@ -35,7 +35,7 @@ impl Output {
 
 	pub fn description(&self) -> &str {
 		unsafe {
-			from_utf8_unchecked(CStr::from_ptr((*self.as_ptr()).name).to_bytes())
+			from_utf8_unchecked(CStr::from_ptr((*self.as_ptr()).long_name).to_bytes())
 		}
 	}
 


### PR DESCRIPTION
This seems to be more reasonable because `name()` is already returning `name`.