### PR TITLE
build/travis: use yasm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rust:
 addons:
   apt:
     packages:
-      - nasm
+      - yasm
 
 script:
   - travis_wait cargo test --verbose --features build


### PR DESCRIPTION
With meh/rust-ffmpeg-sys#36, this should fix Travis error on stable and beta.