### PR TITLE
Add `Parameters` API

### DIFF
--- a/examples/transcode-audio.rs
+++ b/examples/transcode-audio.rs
@@ -75,7 +75,7 @@ fn transcoder<P: AsRef<Path>>(ictx: &mut format::context::Input, octx: &mut form
 	output.set_time_base((1, decoder.rate() as i32));
 
 	let encoder = try!(encoder.open_as(codec));
-	output.set_parameters(&***encoder);
+	output.set_parameters(&encoder);
 
 	let filter  = try!(filter(filter_spec, &decoder, &encoder));
 

--- a/examples/transcode-audio.rs
+++ b/examples/transcode-audio.rs
@@ -50,7 +50,7 @@ fn transcoder<P: AsRef<Path>>(ictx: &mut format::context::Input, octx: &mut form
 	let codec   = try!(ffmpeg::encoder::find(octx.format().codec(path, media::Type::Audio)).expect("failed to find encoder").audio());
 	let global  = octx.format().flags().contains(ffmpeg::format::flag::GLOBAL_HEADER);
 
-	try!(decoder.set_parameters(&input.parameters()));
+	try!(decoder.set_parameters(input.parameters()));
 
 	let mut output  = try!(octx.add_stream(codec));
 	let mut encoder = try!(output.codec().encoder().audio());

--- a/examples/transcode-audio.rs
+++ b/examples/transcode-audio.rs
@@ -51,7 +51,7 @@ fn transcoder<P: AsRef<Path>>(ictx: &mut format::context::Input, octx: &mut form
 	let codec   = try!(ffmpeg::encoder::find(octx.format().codec(path, media::Type::Audio)).expect("failed to find encoder").audio());
 	let global  = octx.format().flags().contains(ffmpeg::format::flag::GLOBAL_HEADER);
 
-	try!(decoder.set_parameters(input.codec_parameters()));
+	try!(decoder.set_parameters(input.parameters()));
 
 	let mut output  = try!(octx.add_stream(codec));
 	let mut encoder = try!(output.codec().encoder().audio());
@@ -75,7 +75,7 @@ fn transcoder<P: AsRef<Path>>(ictx: &mut format::context::Input, octx: &mut form
 	output.set_time_base((1, decoder.rate() as i32));
 
 	let encoder = try!(encoder.open_as(codec));
-	try!(output.set_codec_parameters_from(&encoder));
+	output.set_parameters(&***encoder);
 
 	let filter  = try!(filter(filter_spec, &decoder, &encoder));
 

--- a/examples/transcode-audio.rs
+++ b/examples/transcode-audio.rs
@@ -4,7 +4,6 @@ use std::env;
 use std::path::Path;
 
 use ffmpeg::{format, codec, frame, media, filter};
-use ffmpeg::option::Settable;
 use ffmpeg::{rescale, Rescale};
 
 fn filter(spec: &str, decoder: &codec::decoder::Audio, encoder: &codec::encoder::Audio) -> Result<filter::Graph, ffmpeg::Error> {
@@ -51,7 +50,7 @@ fn transcoder<P: AsRef<Path>>(ictx: &mut format::context::Input, octx: &mut form
 	let codec   = try!(ffmpeg::encoder::find(octx.format().codec(path, media::Type::Audio)).expect("failed to find encoder").audio());
 	let global  = octx.format().flags().contains(ffmpeg::format::flag::GLOBAL_HEADER);
 
-	try!(decoder.set_parameters(input.parameters()));
+	try!(decoder.set_parameters(&input.parameters()));
 
 	let mut output  = try!(octx.add_stream(codec));
 	let mut encoder = try!(output.codec().encoder().audio());

--- a/src/codec/context.rs
+++ b/src/codec/context.rs
@@ -4,8 +4,8 @@ use std::rc::Rc;
 use libc::c_int;
 use ffi::*;
 use ::media;
-use ::Codec;
-use super::{Flags, Id, Debug, Compliance, threading};
+use ::{Codec, Error};
+use super::{Flags, Id, Debug, Compliance, threading, Parameters};
 use super::decoder::Decoder;
 use super::encoder::Encoder;
 
@@ -103,6 +103,15 @@ impl Context {
 			}
 		}
 	}
+
+	pub fn set_parameters(&mut self, params: &Parameters) -> Result<(), Error> {
+        unsafe {
+            match avcodec_parameters_to_context(self.as_mut_ptr(), params.as_ptr()) {
+                e if e < 0 => Err(Error::from(e)),
+                _          => Ok(()),
+            }
+        }
+    }
 }
 
 impl Drop for Context {

--- a/src/codec/context.rs
+++ b/src/codec/context.rs
@@ -104,9 +104,11 @@ impl Context {
 		}
 	}
 
-	pub fn set_parameters(&mut self, params: &Parameters) -> Result<(), Error> {
+	pub fn set_parameters<P: Into<Parameters>>(&mut self, parameters: P)
+		-> Result<(), Error> {
+		let parameters = parameters.into();
         unsafe {
-            match avcodec_parameters_to_context(self.as_mut_ptr(), params.as_ptr()) {
+            match avcodec_parameters_to_context(self.as_mut_ptr(), parameters.as_ptr()) {
                 e if e < 0 => Err(Error::from(e)),
                 _          => Ok(()),
             }

--- a/src/codec/decoder/audio.rs
+++ b/src/codec/decoder/audio.rs
@@ -124,3 +124,9 @@ impl AsRef<Context> for Audio {
 		&self
 	}
 }
+
+impl AsMut<Context> for Audio {
+	fn as_mut(&mut self) -> &mut Context {
+		&mut self.0
+	}
+}

--- a/src/codec/decoder/audio.rs
+++ b/src/codec/decoder/audio.rs
@@ -7,6 +7,7 @@ use super::Opened;
 use ::{packet, Error, AudioService, ChannelLayout};
 use ::frame;
 use ::util::format;
+use ::codec::Context;
 
 pub struct Audio(pub Opened);
 
@@ -115,5 +116,11 @@ impl Deref for Audio {
 impl DerefMut for Audio {
 	fn deref_mut(&mut self) -> &mut<Self as Deref>::Target {
 		&mut self.0
+	}
+}
+
+impl AsRef<Context> for Audio {
+	fn as_ref(&self) -> &Context {
+		&self
 	}
 }

--- a/src/codec/decoder/decoder.rs
+++ b/src/codec/decoder/decoder.rs
@@ -128,3 +128,9 @@ impl DerefMut for Decoder {
 		&mut self.0
 	}
 }
+
+impl AsRef<Context> for Decoder {
+	fn as_ref(&self) -> &Context {
+		&self
+	}
+}

--- a/src/codec/decoder/decoder.rs
+++ b/src/codec/decoder/decoder.rs
@@ -134,3 +134,9 @@ impl AsRef<Context> for Decoder {
 		&self
 	}
 }
+
+impl AsMut<Context> for Decoder {
+	fn as_mut(&mut self) -> &mut Context {
+		&mut self.0
+	}
+}

--- a/src/codec/decoder/opened.rs
+++ b/src/codec/decoder/opened.rs
@@ -2,7 +2,7 @@ use std::ops::{Deref, DerefMut};
 
 use ffi::*;
 use super::{Video, Audio, Subtitle, Decoder};
-use ::codec::Profile;
+use ::codec::{Profile, Context};
 use ::{Error, Rational};
 use ::media;
 
@@ -93,5 +93,11 @@ impl Deref for Opened {
 impl DerefMut for Opened {
 	fn deref_mut(&mut self) -> &mut<Self as Deref>::Target {
 		&mut self.0
+	}
+}
+
+impl AsRef<Context> for Opened {
+	fn as_ref(&self) -> &Context {
+		&self
 	}
 }

--- a/src/codec/decoder/opened.rs
+++ b/src/codec/decoder/opened.rs
@@ -101,3 +101,9 @@ impl AsRef<Context> for Opened {
 		&self
 	}
 }
+
+impl AsMut<Context> for Opened {
+	fn as_mut(&mut self) -> &mut Context {
+		&mut self.0
+	}
+}

--- a/src/codec/decoder/subtitle.rs
+++ b/src/codec/decoder/subtitle.rs
@@ -41,3 +41,9 @@ impl AsRef<Context> for Subtitle {
 		&self
 	}
 }
+
+impl AsMut<Context> for Subtitle {
+	fn as_mut(&mut self) -> &mut Context {
+		&mut self.0
+	}
+}

--- a/src/codec/decoder/subtitle.rs
+++ b/src/codec/decoder/subtitle.rs
@@ -5,6 +5,7 @@ use ffi::*;
 
 use super::Opened;
 use ::{packet, Error};
+use ::codec::Context;
 
 pub struct Subtitle(pub Opened);
 
@@ -32,5 +33,11 @@ impl Deref for Subtitle {
 impl DerefMut for Subtitle {
 	fn deref_mut(&mut self) -> &mut<Self as Deref>::Target {
 		&mut self.0
+	}
+}
+
+impl AsRef<Context> for Subtitle {
+	fn as_ref(&self) -> &Context {
+		&self
 	}
 }

--- a/src/codec/decoder/video.rs
+++ b/src/codec/decoder/video.rs
@@ -156,3 +156,9 @@ impl AsRef<Context> for Video {
 		&self
 	}
 }
+
+impl AsMut<Context> for Video {
+	fn as_mut(&mut self) -> &mut Context {
+		&mut self.0
+	}
+}

--- a/src/codec/decoder/video.rs
+++ b/src/codec/decoder/video.rs
@@ -9,6 +9,7 @@ use ::frame;
 use ::util::format;
 use ::util::chroma;
 use ::color;
+use ::codec::Context;
 
 pub struct Video(pub Opened);
 
@@ -150,3 +151,8 @@ impl DerefMut for Video {
 	}
 }
 
+impl AsRef<Context> for Video {
+	fn as_ref(&self) -> &Context {
+		&self
+	}
+}

--- a/src/codec/encoder/audio.rs
+++ b/src/codec/encoder/audio.rs
@@ -7,7 +7,7 @@ use ffi::*;
 use super::Encoder as Super;
 use ::{packet, Error, Dictionary, ChannelLayout, frame};
 use ::util::format;
-use codec::traits;
+use codec::{traits, Context};
 
 pub struct Audio(pub Super);
 
@@ -131,6 +131,12 @@ impl DerefMut for Audio {
 	}
 }
 
+impl AsRef<Context> for Audio {
+	fn as_ref(&self) -> &Context {
+		&self
+	}
+}
+
 pub struct Encoder(pub Audio);
 
 impl Encoder {
@@ -172,5 +178,11 @@ impl Deref for Encoder {
 
 	fn deref(&self) -> &<Self as Deref>::Target {
 		&self.0
+	}
+}
+
+impl AsRef<Context> for Encoder {
+	fn as_ref(&self) -> &Context {
+		&self
 	}
 }

--- a/src/codec/encoder/audio.rs
+++ b/src/codec/encoder/audio.rs
@@ -137,6 +137,12 @@ impl AsRef<Context> for Audio {
 	}
 }
 
+impl AsMut<Context> for Audio {
+	fn as_mut(&mut self) -> &mut Context {
+		&mut self.0
+	}
+}
+
 pub struct Encoder(pub Audio);
 
 impl Encoder {
@@ -184,5 +190,11 @@ impl Deref for Encoder {
 impl AsRef<Context> for Encoder {
 	fn as_ref(&self) -> &Context {
 		&self
+	}
+}
+
+impl AsMut<Context> for Encoder {
+	fn as_mut(&mut self) -> &mut Context {
+		&mut self.0
 	}
 }

--- a/src/codec/encoder/encoder.rs
+++ b/src/codec/encoder/encoder.rs
@@ -135,3 +135,9 @@ impl DerefMut for Encoder {
 		&mut self.0
 	}
 }
+
+impl AsRef<Context> for Encoder {
+	fn as_ref(&self) -> &Context {
+		&self
+	}
+}

--- a/src/codec/encoder/encoder.rs
+++ b/src/codec/encoder/encoder.rs
@@ -141,3 +141,9 @@ impl AsRef<Context> for Encoder {
 		&self
 	}
 }
+
+impl AsMut<Context> for Encoder {
+	fn as_mut(&mut self) -> &mut Context {
+		&mut *self
+	}
+}

--- a/src/codec/encoder/subtitle.rs
+++ b/src/codec/encoder/subtitle.rs
@@ -74,6 +74,12 @@ impl AsRef<Context> for Subtitle {
 	}
 }
 
+impl AsMut<Context> for Subtitle {
+	fn as_mut(&mut self) -> &mut Context {
+		&mut self.0
+	}
+}
+
 pub struct Encoder(pub Subtitle);
 
 impl Encoder {
@@ -98,5 +104,11 @@ impl Deref for Encoder {
 impl AsRef<Context> for Encoder {
 	fn as_ref(&self) -> &Context {
 		&self
+	}
+}
+
+impl AsMut<Context> for Encoder {
+	fn as_mut(&mut self) -> &mut Context {
+		&mut self.0
 	}
 }

--- a/src/codec/encoder/subtitle.rs
+++ b/src/codec/encoder/subtitle.rs
@@ -6,7 +6,7 @@ use ffi::*;
 
 use super::Encoder as Super;
 use ::{Error, Dictionary};
-use codec::traits;
+use codec::{traits, Context};
 
 pub struct Subtitle(pub Super);
 
@@ -68,6 +68,12 @@ impl DerefMut for Subtitle {
 	}
 }
 
+impl AsRef<Context> for Subtitle {
+	fn as_ref(&self) -> &Context {
+		&self
+	}
+}
+
 pub struct Encoder(pub Subtitle);
 
 impl Encoder {
@@ -86,5 +92,11 @@ impl Deref for Encoder {
 
 	fn deref(&self) -> &<Self as Deref>::Target {
 		&self.0
+	}
+}
+
+impl AsRef<Context> for Encoder {
+	fn as_ref(&self) -> &Context {
+		&self
 	}
 }

--- a/src/codec/encoder/video.rs
+++ b/src/codec/encoder/video.rs
@@ -7,7 +7,7 @@ use ffi::*;
 use super::Encoder as Super;
 use super::{MotionEstimation, Prediction, Comparison, Decision};
 use ::{packet, Error, Rational, Dictionary, frame, format};
-use codec::traits;
+use codec::{traits, Context};
 
 pub struct Video(pub Super);
 
@@ -382,6 +382,12 @@ impl DerefMut for Video {
 	}
 }
 
+impl AsRef<Context> for Video {
+	fn as_ref(&self) -> &Context {
+		&self
+	}
+}
+
 pub struct Encoder(pub Video);
 
 impl Encoder {
@@ -434,5 +440,11 @@ impl DerefMut for Encoder {
 	#[inline]
 	fn deref_mut(&mut self) -> &mut <Self as Deref>::Target {
 		&mut self.0
+	}
+}
+
+impl AsRef<Context> for Encoder {
+	fn as_ref(&self) -> &Context {
+		&self
 	}
 }

--- a/src/codec/encoder/video.rs
+++ b/src/codec/encoder/video.rs
@@ -388,6 +388,12 @@ impl AsRef<Context> for Video {
 	}
 }
 
+impl AsMut<Context> for Video {
+	fn as_mut(&mut self) -> &mut Context {
+		&mut self.0
+	}
+}
+
 pub struct Encoder(pub Video);
 
 impl Encoder {
@@ -446,5 +452,11 @@ impl DerefMut for Encoder {
 impl AsRef<Context> for Encoder {
 	fn as_ref(&self) -> &Context {
 		&self
+	}
+}
+
+impl AsMut<Context> for Encoder {
+	fn as_mut(&mut self) -> &mut Context {
+		&mut self.0
 	}
 }

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -20,6 +20,9 @@ pub use self::capabilities::Capabilities;
 
 pub mod codec;
 
+pub mod parameters;
+pub use self::parameters::Parameters;
+
 pub mod video;
 pub use self::video::Video;
 

--- a/src/codec/parameters.rs
+++ b/src/codec/parameters.rs
@@ -1,6 +1,8 @@
 use std::rc::Rc;
 
 use ffi::*;
+use media;
+use super::Id;
 
 pub struct Parameters {
 	ptr: *mut AVCodecParameters,
@@ -30,6 +32,17 @@ impl Parameters {
 		}
 	}
 
+	pub fn medium(&self) -> media::Type {
+		unsafe {
+			media::Type::from((*self.as_ptr()).codec_type)
+		}
+	}
+
+	pub fn id(&self) -> Id {
+		unsafe {
+			Id::from((*self.as_ptr()).codec_id)
+		}
+	}
 }
 
 impl Drop for Parameters {

--- a/src/codec/parameters.rs
+++ b/src/codec/parameters.rs
@@ -70,9 +70,10 @@ impl Clone for Parameters {
 	}
 }
 
-impl<'a> From<&'a Context> for Parameters {
-	fn from(context: &'a Context) -> Parameters {
+impl<C: AsRef<Context>> From<C> for Parameters {
+	fn from(context: C) -> Parameters {
 		let mut parameters = Parameters::new();
+		let context = context.as_ref();
 		unsafe {
 			avcodec_parameters_from_context(parameters.as_mut_ptr(), context.as_ptr());
 		}

--- a/src/codec/parameters.rs
+++ b/src/codec/parameters.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use ffi::*;
 use media;
-use super::Id;
+use super::{Id, Context};
 
 pub struct Parameters {
 	ptr: *mut AVCodecParameters,
@@ -67,5 +67,15 @@ impl Clone for Parameters {
 		unsafe {
 			avcodec_parameters_copy(self.as_mut_ptr(), source.as_ptr());
 		}
+	}
+}
+
+impl<'a> From<&'a Context> for Parameters {
+	fn from(context: &'a Context) -> Parameters {
+		let mut parameters = Parameters::new();
+		unsafe {
+			avcodec_parameters_from_context(parameters.as_mut_ptr(), context.as_ptr());
+		}
+		parameters
 	}
 }

--- a/src/codec/parameters.rs
+++ b/src/codec/parameters.rs
@@ -1,0 +1,58 @@
+use std::rc::Rc;
+
+use ffi::*;
+
+pub struct Parameters {
+	ptr: *mut AVCodecParameters,
+	owner: Option<Rc<Drop>>,
+}
+
+unsafe impl Send for Parameters {}
+
+impl Parameters {
+	pub unsafe fn wrap(ptr: *mut AVCodecParameters, owner: Option<Rc<Drop>>) -> Self {
+		Parameters { ptr: ptr, owner: owner }
+	}
+
+	pub unsafe fn as_ptr(&self) -> *const AVCodecParameters {
+		self.ptr as *const _
+	}
+
+	pub unsafe fn as_mut_ptr(&mut self) -> *mut AVCodecParameters {
+		self.ptr
+	}
+}
+
+impl Parameters {
+	pub fn new() -> Self {
+		unsafe {
+			Parameters { ptr: avcodec_parameters_alloc(), owner: None }
+		}
+	}
+
+}
+
+impl Drop for Parameters {
+	fn drop(&mut self) {
+		unsafe {
+			if self.owner.is_none() {
+				avcodec_parameters_free(&mut self.as_mut_ptr());
+			}
+		}
+	}
+}
+
+impl Clone for Parameters {
+	fn clone(&self) -> Self {
+		let mut ctx = Parameters::new();
+		ctx.clone_from(self);
+
+		ctx
+	}
+
+	fn clone_from(&mut self, source: &Self) {
+		unsafe {
+			avcodec_parameters_copy(self.as_mut_ptr(), source.as_ptr());
+		}
+	}
+}

--- a/src/format/stream/stream.rs
+++ b/src/format/stream/stream.rs
@@ -27,6 +27,12 @@ impl<'a> Stream<'a> {
 		}
 	}
 
+	pub fn codec_parameters(&self) -> codec::Parameters {
+		unsafe {
+			codec::Parameters::wrap((*self.as_ptr()).codecpar, Some(self.context.destructor()))
+		}
+	}
+
 	pub fn index(&self) -> usize {
 		unsafe {
 			(*self.as_ptr()).index as usize

--- a/src/format/stream/stream.rs
+++ b/src/format/stream/stream.rs
@@ -27,7 +27,7 @@ impl<'a> Stream<'a> {
 		}
 	}
 
-	pub fn codec_parameters(&self) -> codec::Parameters {
+	pub fn parameters(&self) -> codec::Parameters {
 		unsafe {
 			codec::Parameters::wrap((*self.as_ptr()).codecpar, Some(self.context.destructor()))
 		}

--- a/src/format/stream/stream_mut.rs
+++ b/src/format/stream/stream_mut.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 use std::mem;
 
 use ffi::*;
-use ::Rational;
+use ::{Rational, Error};
 use super::Stream;
 use format::context::common::Context;
 
@@ -40,6 +40,15 @@ impl<'a> StreamMut<'a> {
 			av_stream_set_r_frame_rate(self.as_mut_ptr(), value.into().into());
 		}
 	}
+
+    pub fn set_codec_parameters_from(&mut self, context: &::codec::Context) -> Result<(), Error> {
+        unsafe {
+            match avcodec_parameters_from_context((*self.as_mut_ptr()).codecpar, context.as_ptr()) {
+                e if e < 0 => Err(Error::from(e)),
+                _          => Ok(()),
+            }
+        }
+    }
 }
 
 impl<'a> Deref for StreamMut<'a> {

--- a/src/format/stream/stream_mut.rs
+++ b/src/format/stream/stream_mut.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 use std::mem;
 
 use ffi::*;
-use ::{Rational, Error};
+use ::{Rational, codec};
 use super::Stream;
 use format::context::common::Context;
 
@@ -41,12 +41,10 @@ impl<'a> StreamMut<'a> {
 		}
 	}
 
-    pub fn set_codec_parameters_from(&mut self, context: &::codec::Context) -> Result<(), Error> {
+    pub fn set_parameters<P: Into<codec::Parameters>>(&mut self, parameters: P) {
+		let parameters = parameters.into();
         unsafe {
-            match avcodec_parameters_from_context((*self.as_mut_ptr()).codecpar, context.as_ptr()) {
-                e if e < 0 => Err(Error::from(e)),
-                _          => Ok(()),
-            }
+			avcodec_parameters_copy((*self.as_mut_ptr()).codecpar, parameters.as_ptr());
         }
     }
 }


### PR DESCRIPTION
As of ffmpeg 3.1, a new `AVCodecParameters` API introduced. (related [post](https://ffmpeg.org/pipermail/ffmpeg-cvslog/2016-April/099152.html))

This PR is an attempt to support it.