### PR TITLE
Close AVIOContext before freeing AVFormatContext

### DIFF
--- a/src/format/context/destructor.rs
+++ b/src/format/context/destructor.rs
@@ -27,8 +27,10 @@ impl Drop for Destructor {
 				Mode::Input =>
 					avformat_close_input(&mut self.ptr),
 
-				Mode::Output =>
-					avformat_free_context(self.ptr),
+				Mode::Output => {
+					avio_close((*self.ptr).pb);
+					avformat_free_context(self.ptr);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
If AVIOContext is not closed program will fail after enough AVFormatContexts were allocated with either unknown error or too many open files error. 

Simple code to reproduce bug:
```
extern crate ffmpeg;
use ffmpeg::format;

fn main() {
    ffmpeg::init().expect("Cannot init ffmpeg");
    let mut count = 0;
    loop {
        let filename = format!("{}_{}.ts", "stream", count);
        format::output(&filename).expect("Can't read output file information");
        println!("Count {}", count);
        count += 1;
    }
}