### PR TITLE
Use correct plane heights in Video frame

### DIFF
--- a/src/util/format/pixel.rs
+++ b/src/util/format/pixel.rs
@@ -312,6 +312,12 @@ impl Descriptor {
 		self.ptr
 	}
 
+	pub fn nb_components(self) -> u8 {
+		unsafe {
+			(*self.as_ptr()).nb_components
+		}
+	}
+
 	pub fn log2_chroma_h(self) -> u8 {
 		unsafe {
 			(*self.as_ptr()).log2_chroma_h

--- a/src/util/format/pixel.rs
+++ b/src/util/format/pixel.rs
@@ -1,3 +1,6 @@
+use std::ffi::CStr;
+use std::str::from_utf8_unchecked;
+
 use ffi::*;
 
 #[derive(Eq, PartialEq, Copy, Clone, Debug)]
@@ -312,9 +315,21 @@ impl Descriptor {
 		self.ptr
 	}
 
+	pub fn name(self) -> &'static str {
+		unsafe {
+			from_utf8_unchecked(CStr::from_ptr((*self.as_ptr()).name).to_bytes())
+		}
+	}
+
 	pub fn nb_components(self) -> u8 {
 		unsafe {
 			(*self.as_ptr()).nb_components
+		}
+	}
+
+	pub fn log2_chroma_w(self) -> u8 {
+		unsafe {
+			(*self.as_ptr()).log2_chroma_w
 		}
 	}
 

--- a/src/util/format/pixel.rs
+++ b/src/util/format/pixel.rs
@@ -303,7 +303,8 @@ impl Pixel {
 
 		if ptr.is_null() {
 			None
-		} else {
+		}
+		else {
 			Some(Descriptor { ptr })
 		}
 	}

--- a/src/util/format/pixel.rs
+++ b/src/util/format/pixel.rs
@@ -299,13 +299,10 @@ unsafe impl Sync for Descriptor {}
 
 impl Pixel {
 	pub fn descriptor(self) -> Option<Descriptor> {
-		let ptr = unsafe { av_pix_fmt_desc_get(self.into()) };
+		unsafe {
+			let ptr = av_pix_fmt_desc_get(self.into());
 
-		if ptr.is_null() {
-			None
-		}
-		else {
-			Some(Descriptor { ptr })
+			ptr.as_ref().map(|ptr| Descriptor { ptr })
 		}
 	}
 }

--- a/src/util/format/pixel.rs
+++ b/src/util/format/pixel.rs
@@ -289,6 +289,38 @@ pub enum Pixel {
 	AYUV64,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct Descriptor {
+	ptr: *const AVPixFmtDescriptor,
+}
+
+unsafe impl Send for Descriptor {}
+unsafe impl Sync for Descriptor {}
+
+impl Pixel {
+	pub fn descriptor(self) -> Option<Descriptor> {
+		let ptr = unsafe { av_pix_fmt_desc_get(self.into()) };
+
+		if ptr.is_null() {
+			None
+		} else {
+			Some(Descriptor { ptr })
+		}
+	}
+}
+
+impl Descriptor {
+	pub fn as_ptr(self) -> *const AVPixFmtDescriptor {
+		self.ptr
+	}
+
+	pub fn log2_chroma_h(self) -> u8 {
+		unsafe {
+			(*self.as_ptr()).log2_chroma_h
+		}
+	}
+}
+
 impl From<AVPixelFormat> for Pixel {
 	#[inline]
 	fn from(value: AVPixelFormat) -> Self {

--- a/src/util/frame/video.rs
+++ b/src/util/frame/video.rs
@@ -259,7 +259,8 @@ impl Video {
 		if let Some(desc) = self.format().descriptor() {
 			let s = desc.log2_chroma_h();
 			(self.height() + (1 << s) - 1) >> s
-		} else {
+		}
+		else {
 			self.height()
 		}
 	}

--- a/src/util/frame/video.rs
+++ b/src/util/frame/video.rs
@@ -298,7 +298,7 @@ impl Video {
 		unsafe {
 			slice::from_raw_parts(
 				mem::transmute((*self.as_ptr()).data[index]),
-				(*self.as_ptr()).linesize[index] as usize * self.plane_height(index) as usize / mem::size_of::<T>())
+				self.stride(index) * self.plane_height(index) as usize / mem::size_of::<T>())
 		}
 	}
 
@@ -315,7 +315,7 @@ impl Video {
 		unsafe {
 			slice::from_raw_parts_mut(
 				mem::transmute((*self.as_mut_ptr()).data[index]),
-				(*self.as_ptr()).linesize[index] as usize * self.plane_height(index) as usize / mem::size_of::<T>())
+				self.stride(index) * self.plane_height(index) as usize / mem::size_of::<T>())
 		}
 	}
 
@@ -327,7 +327,7 @@ impl Video {
 
 		unsafe {
 			slice::from_raw_parts((*self.as_ptr()).data[index],
-				(*self.as_ptr()).linesize[index] as usize * self.plane_height(index) as usize)
+				self.stride(index) * self.plane_height(index) as usize)
 		}
 	}
 
@@ -339,7 +339,7 @@ impl Video {
 
 		unsafe {
 			slice::from_raw_parts_mut((*self.as_mut_ptr()).data[index],
-				(*self.as_ptr()).linesize[index] as usize * self.plane_height(index) as usize)
+				self.stride(index) * self.plane_height(index) as usize)
 		}
 	}
 }

--- a/src/util/frame/video.rs
+++ b/src/util/frame/video.rs
@@ -256,12 +256,11 @@ impl Video {
 			return self.height();
 		}
 
-		match self.format().descriptor() {
-			None => self.height(),
-			Some(desc) => {
-				let s = desc.log2_chroma_h();
-				(self.height() + (1 << s) - 1) >> s
-			}
+		if let Some(desc) = self.format().descriptor() {
+			let s = desc.log2_chroma_h();
+			(self.height() + (1 << s) - 1) >> s
+		} else {
+			self.height()
 		}
 	}
 

--- a/src/util/frame/video.rs
+++ b/src/util/frame/video.rs
@@ -245,7 +245,12 @@ impl Video {
 		8
 	}
 
-	fn plane_height(&self, index: usize) -> u32 {
+	#[inline]
+	pub fn plane_height(&self, index: usize) -> u32 {
+		if index >= self.planes() {
+			panic!("out of bounds");
+		}
+
 		// Logic taken from av_image_fill_pointers().
 		if index != 1 && index != 2 {
 			return self.height();

--- a/src/util/frame/video.rs
+++ b/src/util/frame/video.rs
@@ -246,6 +246,26 @@ impl Video {
 	}
 
 	#[inline]
+	pub fn plane_width(&self, index: usize) -> u32 {
+		if index >= self.planes() {
+			panic!("out of bounds");
+		}
+
+		// Logic taken from image_get_linesize().
+		if index != 1 && index != 2 {
+			return self.width();
+		}
+
+		if let Some(desc) = self.format().descriptor() {
+			let s = desc.log2_chroma_w();
+			(self.width() + (1 << s) - 1) >> s
+		}
+		else {
+			self.width()
+		}
+	}
+
+	#[inline]
 	pub fn plane_height(&self, index: usize) -> u32 {
 		if index >= self.planes() {
 			panic!("out of bounds");

--- a/src/util/frame/video.rs
+++ b/src/util/frame/video.rs
@@ -258,7 +258,6 @@ impl Video {
 
 		match self.format().descriptor() {
 			None => self.height(),
-
 			Some(desc) => {
 				let s = desc.log2_chroma_h();
 				(self.height() + (1 << s) - 1) >> s


### PR DESCRIPTION
Fixes #80 

Done according to https://www.ffmpeg.org/doxygen/2.3/imgutils_8c_source.html#l00110. Tested with YUV420P (in this pixel format U and V planes are half as wide and high as the Y plane).