### PR TITLE
Couple small changes

### DIFF
--- a/src/codec/packet/packet.rs
+++ b/src/codec/packet/packet.rs
@@ -264,7 +264,7 @@ impl Clone for Packet {
 impl Drop for Packet {
 	fn drop(&mut self) {
 		unsafe {
-			av_free_packet(&mut self.0);
+			av_packet_unref(&mut self.0);
 		}
 	}
 }

--- a/src/codec/subtitle/mod.rs
+++ b/src/codec/subtitle/mod.rs
@@ -105,7 +105,7 @@ impl Subtitle {
 				(mem::size_of::<*const AVSubtitleRect>() * self.0.num_rects as usize) as size_t)
 				as *mut _;
 
-			let mut rect = av_mallocz(mem::size_of::<AVSubtitleRect>() as size_t) as *mut AVSubtitleRect;
+			let rect = av_mallocz(mem::size_of::<AVSubtitleRect>() as size_t) as *mut AVSubtitleRect;
 			(*rect).type_ = kind.into();
 
 			*self.0.rects.offset((self.0.num_rects - 1) as isize) = rect;

--- a/src/filter/graph.rs
+++ b/src/filter/graph.rs
@@ -134,7 +134,7 @@ impl<'a> Parser<'a> {
 	pub fn input(mut self, name: &str, pad: usize) -> Result<Self, Error> {
 		unsafe {
 			let mut context = try!(self.graph.get(name).ok_or(Error::InvalidData));
-			let mut input   = avfilter_inout_alloc();
+			let input   = avfilter_inout_alloc();
 
 			if input.is_null() {
 				panic!("out of memory");
@@ -161,7 +161,7 @@ impl<'a> Parser<'a> {
 	pub fn output(mut self, name: &str, pad: usize) -> Result<Self, Error> {
 		unsafe {
 			let mut context = try!(self.graph.get(name).ok_or(Error::InvalidData));
-			let mut output  = avfilter_inout_alloc();
+			let output  = avfilter_inout_alloc();
 
 			if output.is_null() {
 				panic!("out of memory");


### PR DESCRIPTION
- Don't use deprecated function for packet dropping (https://www.ffmpeg.org/doxygen/3.0/group__lavc__packet.html#gad4af16def8aacf1089ddb7c51729e547)
- Fix compiler warning about values, which do not need to be mutable
![screenshot_20170822_161853](https://user-images.githubusercontent.com/500703/29567541-3b3a9a06-8756-11e7-9dea-f2c43485d967.png)
