### PR TITLE
Compile even if not all cases are handled

### DIFF
--- a/src/codec/id.rs
+++ b/src/codec/id.rs
@@ -951,6 +951,7 @@ impl From<AVCodecID> for Id {
 			AV_CODEC_ID_PCM_F24LE       => Id::PCM_F24LE,
 			AV_CODEC_ID_ATRAC3AL        => Id::ATRAC3AL,
 			AV_CODEC_ID_ATRAC3PAL       => Id::ATRAC3PAL,
+			_ => unimplemented!(),
 		}
 	}
 }

--- a/src/codec/packet/side_data.rs
+++ b/src/codec/packet/side_data.rs
@@ -58,6 +58,7 @@ impl From<AVPacketSideDataType> for Type {
 			AV_PKT_DATA_MASTERING_DISPLAY_METADATA => Type::MasteringDisplayMetadata,
 			AV_PKT_DATA_SPHERICAL                  => Type::DataSpherical,
 			AV_PKT_DATA_NB                         => Type::DataNb,
+			_ => unimplemented!(),
 		}
 	}
 }

--- a/src/util/color/space.rs
+++ b/src/util/color/space.rs
@@ -45,6 +45,7 @@ impl From<AVColorSpace> for Space {
 			AVCOL_SPC_BT2020_CL   => Space::BT2020CL,
 			AVCOL_SPC_SMPTE2085   => Space::SMPTE2085,
 			AVCOL_SPC_NB          => Space::Unspecified,
+			_ => unimplemented!(),
 		}
 	}
 }

--- a/src/util/format/pixel.rs
+++ b/src/util/format/pixel.rs
@@ -579,6 +579,7 @@ impl From<AVPixelFormat> for Pixel {
 			AV_PIX_FMT_P016BE => Pixel::P016BE,
 
 			AV_PIX_FMT_NB => Pixel::None,
+			_ => unimplemented!(),
 		}
 	}
 }

--- a/src/util/frame/side_data.rs
+++ b/src/util/frame/side_data.rs
@@ -53,6 +53,7 @@ impl From<AVFrameSideDataType> for Type {
 			AV_FRAME_DATA_MASTERING_DISPLAY_METADATA => Type::MasteringDisplayMetadata,
 			AV_FRAME_DATA_GOP_TIMECODE       => Type::GOPTimecode,
 			AV_FRAME_DATA_SPHERICAL          => Type::Spherical,
+			_ => unimplemented!(),
 		}
 	}
 }


### PR DESCRIPTION
These enums are likely to get out of sync with ffmpeg_sys, so some flexibility may be useful.