### PR TITLE
Added the newest enum values from ffmpeg-sys.

### DIFF
--- a/src/codec/id.rs
+++ b/src/codec/id.rs
@@ -472,6 +472,15 @@ pub enum Id {
 	PCM_F24LE,
 	ATRAC3AL,
 	ATRAC3PAL,
+
+	BITPACKED,
+	MSCC,
+	SRGC,
+	SVG,
+	GDV,
+	FITS,
+	GREMLIN_DPCM,
+	DOLBY_E,
 }
 
 impl Id {
@@ -951,6 +960,15 @@ impl From<AVCodecID> for Id {
 			AV_CODEC_ID_PCM_F24LE       => Id::PCM_F24LE,
 			AV_CODEC_ID_ATRAC3AL        => Id::ATRAC3AL,
 			AV_CODEC_ID_ATRAC3PAL       => Id::ATRAC3PAL,
+
+			AV_CODEC_ID_BITPACKED       => Id::BITPACKED,
+			AV_CODEC_ID_MSCC            => Id::MSCC,
+			AV_CODEC_ID_SRGC            => Id::SRGC,
+			AV_CODEC_ID_SVG             => Id::SVG,
+			AV_CODEC_ID_GDV             => Id::GDV,
+			AV_CODEC_ID_FITS            => Id::FITS,
+			AV_CODEC_ID_GREMLIN_DPCM    => Id::GREMLIN_DPCM,
+			AV_CODEC_ID_DOLBY_E         => Id::DOLBY_E,
 		}
 	}
 }
@@ -1422,6 +1440,15 @@ impl Into<AVCodecID> for Id {
 			Id::PCM_F24LE  => AV_CODEC_ID_PCM_F24LE,
 			Id::ATRAC3AL   => AV_CODEC_ID_ATRAC3AL,
 			Id::ATRAC3PAL  => AV_CODEC_ID_ATRAC3PAL,
+
+			Id::BITPACKED    => AV_CODEC_ID_BITPACKED,
+			Id::MSCC         => AV_CODEC_ID_MSCC,
+			Id::SRGC         => AV_CODEC_ID_SRGC,
+			Id::SVG          => AV_CODEC_ID_SVG,
+			Id::GDV          => AV_CODEC_ID_GDV,
+			Id::FITS         => AV_CODEC_ID_FITS,
+			Id::GREMLIN_DPCM => AV_CODEC_ID_GREMLIN_DPCM,
+			Id::DOLBY_E      => AV_CODEC_ID_DOLBY_E,
 		}
 	}
 }

--- a/src/codec/packet/side_data.rs
+++ b/src/codec/packet/side_data.rs
@@ -30,6 +30,9 @@ pub enum Type {
 	MasteringDisplayMetadata,
 	DataSpherical,
 	DataNb,
+
+	ContentLightLevel,
+	A53CC,
 }
 
 impl From<AVPacketSideDataType> for Type {
@@ -58,6 +61,9 @@ impl From<AVPacketSideDataType> for Type {
 			AV_PKT_DATA_MASTERING_DISPLAY_METADATA => Type::MasteringDisplayMetadata,
 			AV_PKT_DATA_SPHERICAL                  => Type::DataSpherical,
 			AV_PKT_DATA_NB                         => Type::DataNb,
+
+			AV_PKT_DATA_CONTENT_LIGHT_LEVEL        => Type::ContentLightLevel,
+			AV_PKT_DATA_A53_CC                     => Type::A53CC,
 		}
 	}
 }
@@ -88,6 +94,9 @@ impl Into<AVPacketSideDataType> for Type {
 			Type::MasteringDisplayMetadata => AV_PKT_DATA_MASTERING_DISPLAY_METADATA,
 			Type::DataSpherical            => AV_PKT_DATA_SPHERICAL,
 			Type::DataNb                   => AV_PKT_DATA_NB,
+
+			Type::ContentLightLevel        => AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
+			Type::A53CC                    => AV_PKT_DATA_A53_CC,
 		}
 	}
 }

--- a/src/util/color/space.rs
+++ b/src/util/color/space.rs
@@ -19,6 +19,10 @@ pub enum Space {
 	BT2020NCL,
 	BT2020CL,
 	SMPTE2085,
+
+	ChromaDerivedNCL,
+	ChromaDerivedCL,
+	ICTCP,
 }
 
 impl Space {
@@ -45,6 +49,10 @@ impl From<AVColorSpace> for Space {
 			AVCOL_SPC_BT2020_CL   => Space::BT2020CL,
 			AVCOL_SPC_SMPTE2085   => Space::SMPTE2085,
 			AVCOL_SPC_NB          => Space::Unspecified,
+
+			AVCOL_SPC_CHROMA_DERIVED_NCL => Space::ChromaDerivedNCL,
+			AVCOL_SPC_CHROMA_DERIVED_CL  => Space::ChromaDerivedCL,
+			AVCOL_SPC_ICTCP              => Space::ICTCP,
 		}
 	}
 }
@@ -65,6 +73,10 @@ impl Into<AVColorSpace> for Space {
 			Space::BT2020NCL   => AVCOL_SPC_BT2020_NCL,
 			Space::BT2020CL    => AVCOL_SPC_BT2020_CL,
 			Space::SMPTE2085   => AVCOL_SPC_SMPTE2085,
+
+			Space::ChromaDerivedNCL => AVCOL_SPC_CHROMA_DERIVED_NCL,
+			Space::ChromaDerivedCL  => AVCOL_SPC_CHROMA_DERIVED_CL,
+			Space::ICTCP            => AVCOL_SPC_ICTCP,
 		}
 	}
 }

--- a/src/util/format/pixel.rs
+++ b/src/util/format/pixel.rs
@@ -301,6 +301,15 @@ pub enum Pixel {
 	GRAY10LE,
 	P016LE,
 	P016BE,
+
+	D3D11,
+	GRAY9BE,
+	GRAY9LE,
+	GBRPF32BE,
+	GBRPF32LE,
+	GBRAPF32BE,
+	GBRAPF32LE,
+	DRM_PRIME,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -579,6 +588,15 @@ impl From<AVPixelFormat> for Pixel {
 			AV_PIX_FMT_P016BE => Pixel::P016BE,
 
 			AV_PIX_FMT_NB => Pixel::None,
+
+			AV_PIX_FMT_D3D11      => Pixel::D3D11,
+			AV_PIX_FMT_GRAY9BE    => Pixel::GRAY9BE,
+			AV_PIX_FMT_GRAY9LE    => Pixel::GRAY9LE,
+			AV_PIX_FMT_GBRPF32BE  => Pixel::GBRPF32BE,
+			AV_PIX_FMT_GBRPF32LE  => Pixel::GBRPF32LE,
+			AV_PIX_FMT_GBRAPF32BE => Pixel::GBRAPF32BE,
+			AV_PIX_FMT_GBRAPF32LE => Pixel::GBRAPF32LE,
+			AV_PIX_FMT_DRM_PRIME  => Pixel::DRM_PRIME,
 		}
 	}
 }
@@ -879,6 +897,15 @@ impl Into<AVPixelFormat> for Pixel {
 			Pixel::GRAY10LE => AV_PIX_FMT_GRAY10LE,
 			Pixel::P016LE => AV_PIX_FMT_P016LE,
 			Pixel::P016BE => AV_PIX_FMT_P016BE,
+
+			Pixel::D3D11      => AV_PIX_FMT_D3D11,
+			Pixel::GRAY9BE    => AV_PIX_FMT_GRAY9BE,
+			Pixel::GRAY9LE    => AV_PIX_FMT_GRAY9LE,
+			Pixel::GBRPF32BE  => AV_PIX_FMT_GBRPF32BE,
+			Pixel::GBRPF32LE  => AV_PIX_FMT_GBRPF32LE,
+			Pixel::GBRAPF32BE => AV_PIX_FMT_GBRAPF32BE,
+			Pixel::GBRAPF32LE => AV_PIX_FMT_GBRAPF32LE,
+			Pixel::DRM_PRIME  => AV_PIX_FMT_DRM_PRIME,
 		}
 	}
 }

--- a/src/util/frame/side_data.rs
+++ b/src/util/frame/side_data.rs
@@ -24,6 +24,9 @@ pub enum Type {
 	MasteringDisplayMetadata,
 	GOPTimecode,
 	Spherical,
+
+	ContentLightLevel,
+	IccProfile,
 }
 
 impl Type {
@@ -53,6 +56,9 @@ impl From<AVFrameSideDataType> for Type {
 			AV_FRAME_DATA_MASTERING_DISPLAY_METADATA => Type::MasteringDisplayMetadata,
 			AV_FRAME_DATA_GOP_TIMECODE       => Type::GOPTimecode,
 			AV_FRAME_DATA_SPHERICAL          => Type::Spherical,
+
+			AV_FRAME_DATA_CONTENT_LIGHT_LEVEL => Type::ContentLightLevel,
+			AV_FRAME_DATA_ICC_PROFILE         => Type::IccProfile,
 		}
 	}
 }
@@ -75,6 +81,9 @@ impl Into<AVFrameSideDataType> for Type {
 			Type::MasteringDisplayMetadata => AV_FRAME_DATA_MASTERING_DISPLAY_METADATA,
 			Type::GOPTimecode      => AV_FRAME_DATA_GOP_TIMECODE,
 			Type::Spherical        => AV_FRAME_DATA_SPHERICAL,
+
+			Type::ContentLightLevel => AV_FRAME_DATA_CONTENT_LIGHT_LEVEL,
+			Type::IccProfile        => AV_FRAME_DATA_ICC_PROFILE,
 		}
 	}
 }


### PR DESCRIPTION
Fixes #101 and addresses the build errors #97 (although this doesn't consider how unhandled  enum values should be dealt with).