### PR TITLE
Add function for accessing stream id

### DIFF
--- a/src/format/stream/stream.rs
+++ b/src/format/stream/stream.rs
@@ -21,6 +21,12 @@ impl<'a> Stream<'a> {
 }
 
 impl<'a> Stream<'a> {
+	pub fn id(&self) -> i32 {
+		unsafe {
+			i32::from((*self.as_ptr()).id)
+		}
+	}
+
 	pub fn codec(&self) -> codec::Context {
 		unsafe {
 			codec::Context::wrap((*self.as_ptr()).codec, Some(self.context.destructor()))


### PR DESCRIPTION
In some cases stream id, which is set by codec is needed. In mpegts case from this field you can access stream pid.