### PR TITLE
Added AVIOContext Wrapper

### DIFF
--- a/examples/transcode-output-stream.rs
+++ b/examples/transcode-output-stream.rs
@@ -1,0 +1,231 @@
+extern crate ffmpeg;
+
+use std::env;
+use std::path::Path;
+
+use ffmpeg::{codec, filter, format, frame, media};
+use ffmpeg::{rescale, Rescale};
+use ffmpeg::format::context::IOContextWrite;
+use std::fs::File;
+
+fn filter(
+    spec: &str,
+    decoder: &codec::decoder::Audio,
+    encoder: &codec::encoder::Audio,
+) -> Result<filter::Graph, ffmpeg::Error> {
+    let mut filter = filter::Graph::new();
+
+    let args = format!(
+        "time_base={}:sample_rate={}:sample_fmt={}:channel_layout=0x{:x}",
+        decoder.time_base(),
+        decoder.rate(),
+        decoder.format().name(),
+        decoder.channel_layout().bits()
+    );
+
+    filter.add(&filter::find("abuffer").unwrap(), "in", &args)?;
+    filter.add(&filter::find("abuffersink").unwrap(), "out", "")?;
+
+    {
+        let mut out = filter.get("out").unwrap();
+
+        out.set_sample_format(encoder.format());
+        out.set_channel_layout(encoder.channel_layout());
+        out.set_sample_rate(encoder.rate());
+    }
+
+    filter.output("in", 0)?.input("out", 0)?.parse(spec)?;
+    filter.validate()?;
+
+    println!("{}", filter.dump());
+
+    if let Some(codec) = encoder.codec() {
+        if !codec
+            .capabilities()
+            .contains(ffmpeg::codec::capabilities::VARIABLE_FRAME_SIZE)
+            {
+                filter
+                    .get("out")
+                    .unwrap()
+                    .sink()
+                    .set_frame_size(encoder.frame_size());
+            }
+    }
+
+    Ok(filter)
+}
+
+struct Transcoder {
+    stream: usize,
+    filter: filter::Graph,
+    decoder: codec::decoder::Audio,
+    encoder: codec::encoder::Audio,
+}
+
+fn transcoder<P: AsRef<Path>>(
+    ictx: &mut format::context::Input,
+    octx: &mut format::context::Output,
+    path: &P,
+    filter_spec: &str,
+) -> Result<Transcoder, ffmpeg::Error> {
+    let input = ictx.streams()
+        .best(media::Type::Audio)
+        .expect("could not find best audio stream");
+    let mut decoder = input.codec().decoder().audio()?;
+    let codec = ffmpeg::encoder::find(octx.format().codec(path, media::Type::Audio))
+        .expect("failed to find encoder")
+        .audio()?;
+    let global = octx.format()
+        .flags()
+        .contains(ffmpeg::format::flag::GLOBAL_HEADER);
+
+    decoder.set_parameters(input.parameters())?;
+
+    let mut output = octx.add_stream(codec)?;
+    let mut encoder = output.codec().encoder().audio()?;
+
+    let channel_layout = codec
+        .channel_layouts()
+        .map(|cls| cls.best(decoder.channel_layout().channels()))
+        .unwrap_or(ffmpeg::channel_layout::STEREO);
+
+    if global {
+        encoder.set_flags(ffmpeg::codec::flag::GLOBAL_HEADER);
+    }
+
+    encoder.set_rate(decoder.rate() as i32);
+    encoder.set_channel_layout(channel_layout);
+    encoder.set_channels(channel_layout.channels());
+    encoder.set_format(
+        codec
+            .formats()
+            .expect("unknown supported formats")
+            .next()
+            .unwrap(),
+    );
+    encoder.set_bit_rate(decoder.bit_rate());
+    encoder.set_max_bit_rate(decoder.max_bit_rate());
+
+    encoder.set_time_base((1, decoder.rate() as i32));
+    output.set_time_base((1, decoder.rate() as i32));
+
+    let encoder = encoder.open_as(codec)?;
+    output.set_parameters(&encoder);
+
+    let filter = filter(filter_spec, &decoder, &encoder)?;
+
+    Ok(Transcoder {
+        stream: input.index(),
+        filter: filter,
+        decoder: decoder,
+        encoder: encoder,
+    })
+}
+
+// Transcode the `best` audio stream of the input file into a the output file while applying a
+// given filter. If no filter was specified the stream gets copied (`anull` filter).
+//
+// Example 1: Transcode *.mp3 file to *.wmv while speeding it up
+// transcode-audio in.mp3 out.wmv "atempo=1.2"
+//
+// Example 2: Overlay an audio file
+// transcode-audio in.mp3 out.mp3 "amovie=overlay.mp3 [ov]; [in][ov] amerge [out]"
+//
+// Example 3: Seek to a specified position (in seconds)
+// transcode-audio in.mp3 out.mp3 anull 30
+fn main() {
+    ffmpeg::init().unwrap();
+
+    let input = env::args().nth(1).expect("missing input");
+    let output = env::args().nth(2).expect("missing output");
+    let filter = env::args().nth(3).unwrap_or_else(|| "anull".to_owned());
+    let seek = env::args().nth(4).and_then(|s| s.parse::<i64>().ok());
+
+    let mut ictx = format::input(&input).unwrap();
+
+    let output_file = File::create(&output).unwrap();
+    let mut output_wrapper = IOContextWrite::new(output_file, 32 * 1024);
+    let mut octx = format::output_stream(output_wrapper, "mp3").unwrap();
+
+    let mut transcoder = transcoder(&mut ictx, &mut octx, &output, &filter).unwrap();
+
+    if let Some(position) = seek {
+        // If the position was given in seconds, rescale it to ffmpegs base timebase.
+        let position = position.rescale((1, 1), rescale::TIME_BASE);
+        // If this seek was embedded in the transcoding loop, a call of `flush()`
+        // for every opened buffer after the successful seek would be advisable.
+        ictx.seek(position, ..position).unwrap();
+    }
+
+    octx.set_metadata(ictx.metadata().to_owned());
+    octx.write_header().unwrap();
+
+    let in_time_base = transcoder.decoder.time_base();
+    let out_time_base = octx.stream(0).unwrap().time_base();
+
+    let mut decoded = frame::Audio::empty();
+    let mut encoded = ffmpeg::Packet::empty();
+
+    for (stream, mut packet) in ictx.packets() {
+        if stream.index() == transcoder.stream {
+            packet.rescale_ts(stream.time_base(), in_time_base);
+
+            if let Ok(true) = transcoder.decoder.decode(&packet, &mut decoded) {
+                let timestamp = decoded.timestamp();
+                decoded.set_pts(timestamp);
+
+                transcoder
+                    .filter
+                    .get("in")
+                    .unwrap()
+                    .source()
+                    .add(&decoded)
+                    .unwrap();
+
+                while let Ok(..) = transcoder
+                    .filter
+                    .get("out")
+                    .unwrap()
+                    .sink()
+                    .frame(&mut decoded)
+                    {
+                        if let Ok(true) = transcoder.encoder.encode(&decoded, &mut encoded) {
+                            encoded.set_stream(0);
+                            encoded.rescale_ts(in_time_base, out_time_base);
+                            encoded.write_interleaved(&mut octx).unwrap();
+                        }
+                    }
+            }
+        }
+    }
+
+    transcoder
+        .filter
+        .get("in")
+        .unwrap()
+        .source()
+        .flush()
+        .unwrap();
+
+    while let Ok(..) = transcoder
+        .filter
+        .get("out")
+        .unwrap()
+        .sink()
+        .frame(&mut decoded)
+        {
+            if let Ok(true) = transcoder.encoder.encode(&decoded, &mut encoded) {
+                encoded.set_stream(0);
+                encoded.rescale_ts(in_time_base, out_time_base);
+                encoded.write_interleaved(&mut octx).unwrap();
+            }
+        }
+
+    if let Ok(true) = transcoder.encoder.flush(&mut encoded) {
+        encoded.set_stream(0);
+        encoded.rescale_ts(in_time_base, out_time_base);
+        encoded.write_interleaved(&mut octx).unwrap();
+    }
+
+    octx.write_trailer().unwrap();
+}

--- a/examples/transcode-output-stream.rs
+++ b/examples/transcode-output-stream.rs
@@ -144,10 +144,11 @@ fn main() {
     let mut ictx = format::input(&input).unwrap();
 
     let output_file = File::create(&output).unwrap();
-    let mut output_wrapper = IOContextWrite::new(output_file, 32 * 1024);
-    let mut octx = format::output_stream(output_wrapper, "mp3").unwrap();
+    let output_wrapper = IOContextWrite::new(output_file, 32 * 1024);
+    let mut octx_wrapped = format::output_stream(output_wrapper, "mp3").unwrap();
+    let mut octx = octx_wrapped.inner_mut();
 
-    let mut transcoder = transcoder(&mut ictx, &mut octx, &output, &filter).unwrap();
+    let mut transcoder = transcoder(&mut ictx, octx, &output, &filter).unwrap();
 
     if let Some(position) = seek {
         // If the position was given in seconds, rescale it to ffmpegs base timebase.

--- a/src/format/context/destructor.rs
+++ b/src/format/context/destructor.rs
@@ -4,6 +4,7 @@ use ffi::*;
 pub enum Mode {
     Input,
     Output,
+    OutputStream,
 }
 
 pub struct Destructor {
@@ -30,6 +31,8 @@ impl Drop for Destructor {
                     avio_close((*self.ptr).pb);
                     avformat_free_context(self.ptr);
                 }
+
+                _ => (),
             }
         }
     }

--- a/src/format/context/io.rs
+++ b/src/format/context/io.rs
@@ -1,0 +1,98 @@
+use ffi::*;
+use libc::c_int;
+use libc::c_void;
+use std::io::Seek;
+use std::io::SeekFrom;
+use std::io::Write;
+use std::slice;
+
+/// A safe wrapper around AVIOContext with a writer and seeker.
+pub struct IOContextWrite<O>
+where
+    O: Write + Seek,
+{
+    buffer: *mut c_void,
+    inner: *mut AVIOContext,
+    output: Box<O>,
+}
+
+unsafe extern "C" fn write_packet<O: Write + Seek>(
+    opaque: *mut c_void,
+    buf: *mut u8,
+    buf_size: c_int,
+) -> c_int {
+    let unwrapped = opaque as *mut O;
+
+    let slice = slice::from_raw_parts(buf, buf_size as usize);
+    let output = &mut unwrapped.as_mut().unwrap();
+
+    if let Err(..) = output.write_all(slice) {
+        return -1;
+    }
+
+    0
+}
+
+unsafe extern "C" fn seek<O: Write + Seek>(opaque: *mut c_void, offset: i64, whence: c_int) -> i64 {
+    let unwrapped = opaque as *mut O;
+    let output = &mut unwrapped.as_mut().unwrap();
+
+    let from = match whence {
+        SEEK_SET => SeekFrom::Start(offset as u64),
+        SEEK_CUR => SeekFrom::Current(offset),
+        SEEK_END => SeekFrom::End(offset),
+        AVSEEK_SIZE | _ => return -1,
+    };
+
+    return match output.seek(from) {
+        Err(..) => -1,
+        Ok(final_offset) => final_offset as i64,
+    };
+}
+
+impl<O> IOContextWrite<O>
+where
+    O: Write + Seek,
+{
+    pub fn new(output: O, buffer_size: i32) -> IOContextWrite<O> {
+        let mut boxed_output = Box::new(output);
+        let boxed_output_ptr: *mut O = &mut *boxed_output;
+
+        // Allocate Buffer
+        let buffer = unsafe { av_malloc(buffer_size as usize) };
+
+        let inner = unsafe {
+            avio_alloc_context(
+                buffer as *mut u8,
+                buffer_size,
+                1,
+                boxed_output_ptr as *mut c_void,
+                None,
+                Some(write_packet::<O>),
+                Some(seek::<O>),
+            )
+        };
+
+        IOContextWrite {
+            buffer,
+            output: boxed_output,
+            inner,
+        }
+    }
+
+    pub fn as_mut_ptr(&mut self) -> *mut AVIOContext {
+        self.inner
+    }
+}
+
+impl<O> Drop for IOContextWrite<O>
+where
+    O: Write + Seek,
+{
+    fn drop(&mut self) {
+        unsafe {
+            av_free(self.inner as *mut c_void);
+            av_free(self.buffer);
+        };
+    }
+}

--- a/src/format/context/io.rs
+++ b/src/format/context/io.rs
@@ -83,6 +83,10 @@ where
     pub fn as_mut_ptr(&mut self) -> *mut AVIOContext {
         self.inner
     }
+
+    pub fn inner(&self) -> &O {
+        &*self.output
+    }
 }
 
 impl<O> Drop for IOContextWrite<O>

--- a/src/format/context/mod.rs
+++ b/src/format/context/mod.rs
@@ -7,6 +7,9 @@ pub use self::input::Input;
 pub mod output;
 pub use self::output::Output;
 
+pub mod io;
+pub use self::io::IOContextWrite;
+
 #[doc(hidden)]
 pub mod common;
 

--- a/src/format/context/mod.rs
+++ b/src/format/context/mod.rs
@@ -6,6 +6,7 @@ pub use self::input::Input;
 
 pub mod output;
 pub use self::output::Output;
+pub use self::output::OutputStream;
 
 pub mod io;
 pub use self::io::IOContextWrite;

--- a/src/format/context/output.rs
+++ b/src/format/context/output.rs
@@ -26,6 +26,13 @@ impl Output {
         }
     }
 
+    pub unsafe fn wrap_stream(ptr: *mut AVFormatContext) -> Self {
+        Output {
+            ptr: ptr,
+            ctx: Context::wrap(ptr, destructor::Mode::OutputStream),
+        }
+    }
+
     pub unsafe fn as_ptr(&self) -> *const AVFormatContext {
         self.ptr as *const _
     }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -234,8 +234,8 @@ pub fn output<P: AsRef<Path>>(path: &P) -> Result<context::Output, Error> {
     }
 }
 
-pub fn output_stream<O: Write + Seek>(
-    stream: &mut IOContextWrite<O>,
+pub fn output_stream<O: Write + Seek + 'static>(
+    mut stream: IOContextWrite<O>,
     format: &str,
 ) -> Result<context::Output, Error> {
     let format = CString::new(format).unwrap();
@@ -258,7 +258,7 @@ pub fn output_stream<O: Write + Seek>(
         let format_context = format_context_ptr.as_mut().unwrap();
         format_context.pb = stream.as_mut_ptr();
         format_context.flags = AVFMT_FLAG_CUSTOM_IO;
-        Ok(context::Output::wrap_stream(format_context_ptr))
+        Ok(context::Output::wrap_stream(format_context_ptr, stream))
     }
 }
 

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -237,7 +237,7 @@ pub fn output<P: AsRef<Path>>(path: &P) -> Result<context::Output, Error> {
 pub fn output_stream<O: Write + Seek + 'static>(
     mut stream: IOContextWrite<O>,
     format: &str,
-) -> Result<context::Output, Error> {
+) -> Result<context::OutputStream<O>, Error> {
     let format = CString::new(format).unwrap();
 
     let mut format_context_ptr = ptr::null_mut();
@@ -258,7 +258,7 @@ pub fn output_stream<O: Write + Seek + 'static>(
         let format_context = format_context_ptr.as_mut().unwrap();
         format_context.pb = stream.as_mut_ptr();
         format_context.flags = AVFMT_FLAG_CUSTOM_IO;
-        Ok(context::Output::wrap_stream(format_context_ptr, stream))
+        Ok(context::OutputStream::wrap(format_context_ptr, stream))
     }
 }
 


### PR DESCRIPTION
Added an AVIOContext wrapper for writing (output from ffmpeg). Check out the commit messages for more details.

An example usage is included.

Here are some resources about AVIOContext:
* https://www.codeproject.com/Tips/489450/Creating-Custom-FFmpeg-IO-Context
* https://libav.org/documentation/doxygen/master/avio_8h.html#a853f5149136a27ffba3207d8520172a5
* https://lists.libav.org/pipermail/libav-api/2012-June/000547.html
* https://github.com/FFmpeg/FFmpeg/blob/master/doc/examples/avio_reading.c