### PR TITLE
Add RefeMut trait to audio::Encoder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,5 +95,6 @@ version  = "0.12"
 optional = true
 
 [dependencies.ffmpeg-sys]
-version = "3.3"
+version = "3.4"
 default-features = false
+git = "https://github.com/bacek/rust-ffmpeg-sys.git"

--- a/src/codec/encoder/audio.rs
+++ b/src/codec/encoder/audio.rs
@@ -193,6 +193,12 @@ impl Deref for Encoder {
     }
 }
 
+impl DerefMut for Encoder {
+    fn deref_mut(&mut self) -> &mut <Self as Deref>::Target {
+        &mut self.0
+    }
+}
+
 impl AsRef<Context> for Encoder {
     fn as_ref(&self) -> &Context {
         self


### PR DESCRIPTION
Looks like it was just missing.