### PR TITLE
null codec is valid

### DIFF
--- a/src/format/context/output.rs
+++ b/src/format/context/output.rs
@@ -72,8 +72,9 @@ impl Output {
 
     pub fn add_stream<E: traits::Encoder>(&mut self, codec: E) -> Result<StreamMut, Error> {
         unsafe {
-            let codec = codec.encoder().ok_or(Error::EncoderNotFound)?;
-            let ptr = avformat_new_stream(self.as_mut_ptr(), codec.as_ptr());
+            let codec = codec.encoder();
+            let codec = codec.map_or(ptr::null(), |c| c.as_ptr());
+            let ptr = avformat_new_stream(self.as_mut_ptr(), codec);
 
             if ptr.is_null() {
                 panic!("out of memory");

--- a/src/format/context/output.rs
+++ b/src/format/context/output.rs
@@ -77,7 +77,7 @@ impl Output {
             let ptr = avformat_new_stream(self.as_mut_ptr(), codec);
 
             if ptr.is_null() {
-                panic!("out of memory");
+                return Err(Error::Unknown);
             }
 
             let index = (*self.ctx.as_ptr()).nb_streams - 1;


### PR DESCRIPTION
This is required for remuxing without reencoding.

Also, panics are not nice. There's no error case for out-of-memory, so I've used a fallback case.