### PR TITLE
Add feature flags to support older ffmpeg versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ keywords    = ["audio", "video"]
 default = ["codec", "device", "filter", "format", "resampling", "software-scaling"]
 
 static = ["ffmpeg-sys/static"]
-build  = ["static", "ffmpeg-sys/build"]
+# Currently the version built by ffmpeg-sys is 4.1
+build  = ["static", "ffmpeg-sys/build", "ffmpeg_4_1"]
 
 # licensing
 build-license-gpl      = ["ffmpeg-sys/build-license-gpl"]
@@ -85,6 +86,16 @@ format              = ["ffmpeg-sys/avformat", "codec"]
 resampling          = ["ffmpeg-sys/swresample"]
 postprocessing      = ["ffmpeg-sys/postproc"]
 software-scaling    = ["ffmpeg-sys/swscale", "codec"]
+
+# The minimum version supported is FFMpeg 3.0, which is enabled automatically
+ffmpeg_3_1 = []
+ffmpeg_3_2 = ["ffmpeg_3_1"]
+ffmpeg_3_3 = ["ffmpeg_3_2"]
+ffmpeg_3_4 = ["ffmpeg_3_3"]
+ffmpeg_4_0 = ["ffmpeg_3_4"]
+ffmpeg_4_1 = ["ffmpeg_4_0"]
+ffmpeg_4_2 = ["ffmpeg_4_1"]
+ffmpeg_4_3 = ["ffmpeg_4_2"]
 
 [dependencies]
 libc      = "0.2"

--- a/src/codec/capabilities.rs
+++ b/src/codec/capabilities.rs
@@ -16,7 +16,9 @@ bitflags! {
         const PARAM_CHANGE        = AV_CODEC_CAP_PARAM_CHANGE;
         const AUTO_THREADS        = AV_CODEC_CAP_AUTO_THREADS;
         const VARIABLE_FRAME_SIZE = AV_CODEC_CAP_VARIABLE_FRAME_SIZE;
+        #[cfg_attr(feature = "ffmpeg_4_3", deprecated)]
         const INTRA_ONLY          = AV_CODEC_CAP_INTRA_ONLY;
+        #[cfg_attr(feature = "ffmpeg_4_3", deprecated)]
         const LOSSLESS            = AV_CODEC_CAP_LOSSLESS;
     }
 }

--- a/src/codec/context.rs
+++ b/src/codec/context.rs
@@ -3,11 +3,13 @@ use std::rc::Rc;
 
 use super::decoder::Decoder;
 use super::encoder::Encoder;
-use super::{threading, Compliance, Debug, Flags, Id, Parameters};
+#[cfg(feature = "ffmpeg_3_1")]
+use super::Parameters;
+use super::{threading, Compliance, Debug, Flags, Id};
 use crate::ffi::*;
-use libc::c_int;
 use crate::media;
 use crate::{Codec, Error};
+use libc::c_int;
 
 pub struct Context {
     ptr: *mut AVCodecContext,
@@ -105,6 +107,7 @@ impl Context {
         }
     }
 
+    #[cfg(feature = "ffmpeg_3_1")]
     pub fn set_parameters<P: Into<Parameters>>(&mut self, parameters: P) -> Result<(), Error> {
         let parameters = parameters.into();
 

--- a/src/codec/id.rs
+++ b/src/codec/id.rs
@@ -95,6 +95,7 @@ pub enum Id {
     MMVIDEO,
     ZMBV,
     AVS,
+    #[cfg(feature = "ffmpeg_4_1")]
     AVS2,
     SMACKVIDEO,
     NUV,
@@ -397,6 +398,7 @@ pub enum Id {
     PAF_AUDIO,
     ON2AVC,
     DSS_SP,
+    #[cfg(feature = "ffmpeg_4_0")]
     CODEC2,
 
     FFWAVESYNTH,
@@ -480,18 +482,29 @@ pub enum Id {
     FITS,
     GREMLIN_DPCM,
     DOLBY_E,
+    #[cfg(feature = "ffmpeg_4_0")]
     APTX,
+    #[cfg(feature = "ffmpeg_4_0")]
     APTX_HD,
+    #[cfg(feature = "ffmpeg_4_0")]
     SBC,
 
+    #[cfg(feature = "ffmpeg_4_1")]
     IMM4,
+    #[cfg(feature = "ffmpeg_4_1")]
     PROSUMER,
+    #[cfg(feature = "ffmpeg_4_1")]
     MWSC,
+    #[cfg(feature = "ffmpeg_4_1")]
     WCMV,
+    #[cfg(feature = "ffmpeg_4_1")]
     RASC,
+    #[cfg(feature = "ffmpeg_4_1")]
     PCM_VIDC,
+    #[cfg(feature = "ffmpeg_4_1")]
     ATRAC9,
 
+    #[cfg(feature = "ffmpeg_4_1")]
     TTML,
 }
 
@@ -596,6 +609,7 @@ impl From<AVCodecID> for Id {
             AV_CODEC_ID_MMVIDEO => Id::MMVIDEO,
             AV_CODEC_ID_ZMBV => Id::ZMBV,
             AV_CODEC_ID_AVS => Id::AVS,
+            #[cfg(feature = "ffmpeg_4_1")]
             AV_CODEC_ID_AVS2 => Id::AVS2,
             AV_CODEC_ID_SMACKVIDEO => Id::SMACKVIDEO,
             AV_CODEC_ID_NUV => Id::NUV,
@@ -766,7 +780,9 @@ impl From<AVCodecID> for Id {
             AV_CODEC_ID_PCM_S64LE => Id::PCM_S64LE,
             AV_CODEC_ID_PCM_S64BE => Id::PCM_S64BE,
 
+            #[cfg(feature = "ffmpeg_4_1")]
             AV_CODEC_ID_PCM_VIDC => Id::PCM_VIDC,
+            #[cfg(feature = "ffmpeg_4_1")]
             AV_CODEC_ID_ATRAC9 => Id::ATRAC9,
 
             /* various ADPCM codecs */
@@ -899,6 +915,7 @@ impl From<AVCodecID> for Id {
             AV_CODEC_ID_PAF_AUDIO => Id::PAF_AUDIO,
             AV_CODEC_ID_ON2AVC => Id::ON2AVC,
             AV_CODEC_ID_DSS_SP => Id::DSS_SP,
+            #[cfg(feature = "ffmpeg_4_0")]
             AV_CODEC_ID_CODEC2 => Id::CODEC2,
 
             AV_CODEC_ID_FFWAVESYNTH => Id::FFWAVESYNTH,
@@ -944,7 +961,6 @@ impl From<AVCodecID> for Id {
             AV_CODEC_ID_HDMV_TEXT_SUBTITLE => Id::HDMV_TEXT_SUBTITLE,
 
             /* other specific kind of codecs (generally used for attachments) */
-
             AV_CODEC_ID_SCTE_35 => Id::SCTE_35,
             AV_CODEC_ID_BINTEXT => Id::BINTEXT,
             AV_CODEC_ID_XBIN => Id::XBIN,
@@ -982,15 +998,24 @@ impl From<AVCodecID> for Id {
             AV_CODEC_ID_FITS => Id::FITS,
             AV_CODEC_ID_GREMLIN_DPCM => Id::GREMLIN_DPCM,
             AV_CODEC_ID_DOLBY_E => Id::DOLBY_E,
+            #[cfg(feature = "ffmpeg_4_0")]
             AV_CODEC_ID_APTX => Id::APTX,
+            #[cfg(feature = "ffmpeg_4_0")]
             AV_CODEC_ID_APTX_HD => Id::APTX_HD,
+            #[cfg(feature = "ffmpeg_4_0")]
             AV_CODEC_ID_SBC => Id::SBC,
 
+            #[cfg(feature = "ffmpeg_4_1")]
             AV_CODEC_ID_IMM4 => Id::IMM4,
+            #[cfg(feature = "ffmpeg_4_1")]
             AV_CODEC_ID_PROSUMER => Id::PROSUMER,
+            #[cfg(feature = "ffmpeg_4_1")]
             AV_CODEC_ID_MWSC => Id::MWSC,
+            #[cfg(feature = "ffmpeg_4_1")]
             AV_CODEC_ID_WCMV => Id::WCMV,
+            #[cfg(feature = "ffmpeg_4_1")]
             AV_CODEC_ID_RASC => Id::RASC,
+            #[cfg(feature = "ffmpeg_4_1")]
             AV_CODEC_ID_TTML => Id::TTML,
 
             _ => unimplemented!(),
@@ -1088,6 +1113,7 @@ impl Into<AVCodecID> for Id {
             Id::MMVIDEO => AV_CODEC_ID_MMVIDEO,
             Id::ZMBV => AV_CODEC_ID_ZMBV,
             Id::AVS => AV_CODEC_ID_AVS,
+            #[cfg(feature = "ffmpeg_4_1")]
             Id::AVS2 => AV_CODEC_ID_AVS2,
             Id::SMACKVIDEO => AV_CODEC_ID_SMACKVIDEO,
             Id::NUV => AV_CODEC_ID_NUV,
@@ -1389,6 +1415,7 @@ impl Into<AVCodecID> for Id {
             Id::PAF_AUDIO => AV_CODEC_ID_PAF_AUDIO,
             Id::ON2AVC => AV_CODEC_ID_ON2AVC,
             Id::DSS_SP => AV_CODEC_ID_DSS_SP,
+            #[cfg(feature = "ffmpeg_4_0")]
             Id::CODEC2 => AV_CODEC_ID_CODEC2,
 
             Id::FFWAVESYNTH => AV_CODEC_ID_FFWAVESYNTH,
@@ -1472,17 +1499,28 @@ impl Into<AVCodecID> for Id {
             Id::FITS => AV_CODEC_ID_FITS,
             Id::GREMLIN_DPCM => AV_CODEC_ID_GREMLIN_DPCM,
             Id::DOLBY_E => AV_CODEC_ID_DOLBY_E,
+            #[cfg(feature = "ffmpeg_4_0")]
             Id::APTX => AV_CODEC_ID_APTX,
+            #[cfg(feature = "ffmpeg_4_0")]
             Id::APTX_HD => AV_CODEC_ID_APTX_HD,
+            #[cfg(feature = "ffmpeg_4_0")]
             Id::SBC => AV_CODEC_ID_SBC,
 
+            #[cfg(feature = "ffmpeg_4_1")]
             Id::IMM4 => AV_CODEC_ID_IMM4,
+            #[cfg(feature = "ffmpeg_4_1")]
             Id::PROSUMER => AV_CODEC_ID_PROSUMER,
+            #[cfg(feature = "ffmpeg_4_1")]
             Id::MWSC => AV_CODEC_ID_MWSC,
+            #[cfg(feature = "ffmpeg_4_1")]
             Id::WCMV => AV_CODEC_ID_WCMV,
+            #[cfg(feature = "ffmpeg_4_1")]
             Id::RASC => AV_CODEC_ID_RASC,
+            #[cfg(feature = "ffmpeg_4_1")]
             Id::PCM_VIDC => AV_CODEC_ID_PCM_VIDC,
+            #[cfg(feature = "ffmpeg_4_1")]
             Id::ATRAC9 => AV_CODEC_ID_ATRAC9,
+            #[cfg(feature = "ffmpeg_4_1")]
             Id::TTML => AV_CODEC_ID_TTML,
         }
     }

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -20,7 +20,9 @@ pub use self::capabilities::Capabilities;
 
 pub mod codec;
 
+#[cfg(feature = "ffmpeg_3_1")]
 pub mod parameters;
+#[cfg(feature = "ffmpeg_3_1")]
 pub use self::parameters::Parameters;
 
 pub mod video;

--- a/src/codec/packet/side_data.rs
+++ b/src/codec/packet/side_data.rs
@@ -26,17 +26,24 @@ pub enum Type {
     WebVTTIdentifier,
     WebVTTSettings,
     MetadataUpdate,
+    #[cfg(feature = "ffmpeg_3_1")]
     MPEGTSStreamID,
     MasteringDisplayMetadata,
+    #[cfg(feature = "ffmpeg_3_3")]
     DataSpherical,
     DataNb,
 
+    #[cfg(feature = "ffmpeg_3_3")]
     ContentLightLevel,
+    #[cfg(feature = "ffmpeg_3_4")]
     A53CC,
 
+    #[cfg(feature = "ffmpeg_4_0")]
     EncryptionInitInfo,
+    #[cfg(feature = "ffmpeg_4_0")]
     EncryptionInfo,
 
+    #[cfg(feature = "ffmpeg_4_1")]
     AFD,
 }
 
@@ -63,15 +70,22 @@ impl From<AVPacketSideDataType> for Type {
             AV_PKT_DATA_WEBVTT_IDENTIFIER => Type::WebVTTIdentifier,
             AV_PKT_DATA_WEBVTT_SETTINGS => Type::WebVTTSettings,
             AV_PKT_DATA_METADATA_UPDATE => Type::MetadataUpdate,
+            #[cfg(feature = "ffmpeg_3_1")]
             AV_PKT_DATA_MPEGTS_STREAM_ID => Type::MPEGTSStreamID,
             AV_PKT_DATA_MASTERING_DISPLAY_METADATA => Type::MasteringDisplayMetadata,
+            #[cfg(feature = "ffmpeg_3_3")]
             AV_PKT_DATA_SPHERICAL => Type::DataSpherical,
             AV_PKT_DATA_NB => Type::DataNb,
 
+            #[cfg(feature = "ffmpeg_3_3")]
             AV_PKT_DATA_CONTENT_LIGHT_LEVEL => Type::ContentLightLevel,
+            #[cfg(feature = "ffmpeg_3_4")]
             AV_PKT_DATA_A53_CC => Type::A53CC,
+            #[cfg(feature = "ffmpeg_4_0")]
             AV_PKT_DATA_ENCRYPTION_INIT_INFO => Type::EncryptionInitInfo,
+            #[cfg(feature = "ffmpeg_4_0")]
             AV_PKT_DATA_ENCRYPTION_INFO => Type::EncryptionInfo,
+            #[cfg(feature = "ffmpeg_4_1")]
             AV_PKT_DATA_AFD => Type::AFD,
 
             _ => unimplemented!(),
@@ -101,15 +115,22 @@ impl Into<AVPacketSideDataType> for Type {
             Type::WebVTTIdentifier => AV_PKT_DATA_WEBVTT_IDENTIFIER,
             Type::WebVTTSettings => AV_PKT_DATA_WEBVTT_SETTINGS,
             Type::MetadataUpdate => AV_PKT_DATA_METADATA_UPDATE,
+            #[cfg(feature = "ffmpeg_3_1")]
             Type::MPEGTSStreamID => AV_PKT_DATA_MPEGTS_STREAM_ID,
             Type::MasteringDisplayMetadata => AV_PKT_DATA_MASTERING_DISPLAY_METADATA,
+            #[cfg(feature = "ffmpeg_3_3")]
             Type::DataSpherical => AV_PKT_DATA_SPHERICAL,
             Type::DataNb => AV_PKT_DATA_NB,
 
+            #[cfg(feature = "ffmpeg_3_3")]
             Type::ContentLightLevel => AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
+            #[cfg(feature = "ffmpeg_3_4")]
             Type::A53CC => AV_PKT_DATA_A53_CC,
+            #[cfg(feature = "ffmpeg_4_0")]
             Type::EncryptionInitInfo => AV_PKT_DATA_ENCRYPTION_INIT_INFO,
+            #[cfg(feature = "ffmpeg_4_0")]
             Type::EncryptionInfo => AV_PKT_DATA_ENCRYPTION_INFO,
+            #[cfg(feature = "ffmpeg_4_1")]
             Type::AFD => AV_PKT_DATA_AFD,
         }
     }

--- a/src/filter/context/sink.rs
+++ b/src/filter/context/sink.rs
@@ -1,7 +1,7 @@
 use super::Context;
 use crate::ffi::*;
-use libc::c_int;
 use crate::{Error, Frame};
+use libc::c_int;
 
 pub struct Sink<'a> {
     ctx: &'a mut Context<'a>,
@@ -14,6 +14,7 @@ impl<'a> Sink<'a> {
 }
 
 impl<'a> Sink<'a> {
+    #[cfg(feature = "ffmpeg_3_3")]
     pub fn frame(&mut self, frame: &mut Frame) -> Result<(), Error> {
         unsafe {
             match av_buffersink_get_frame(self.ctx.as_mut_ptr(), frame.as_mut_ptr()) {
@@ -23,6 +24,7 @@ impl<'a> Sink<'a> {
         }
     }
 
+    #[cfg(feature = "ffmpeg_3_3")]
     pub fn samples(&mut self, frame: &mut Frame, samples: usize) -> Result<(), Error> {
         unsafe {
             match av_buffersink_get_samples(

--- a/src/format/stream/stream.rs
+++ b/src/format/stream/stream.rs
@@ -2,8 +2,8 @@ use super::Disposition;
 use crate::codec::{self, packet};
 use crate::ffi::*;
 use crate::format::context::common::Context;
-use libc::c_int;
 use crate::{DictionaryRef, Discard, Rational};
+use libc::c_int;
 
 #[derive(Debug)]
 pub struct Stream<'a> {
@@ -33,9 +33,16 @@ impl<'a> Stream<'a> {
         unsafe { codec::Context::wrap((*self.as_ptr()).codec, Some(self.context.destructor())) }
     }
 
+    #[cfg(feature = "ffmpeg_3_1")]
     pub fn parameters(&self) -> codec::Parameters {
+        #[cfg(feature = "ffmpeg_3_1")]
         unsafe {
             codec::Parameters::wrap((*self.as_ptr()).codecpar, Some(self.context.destructor()))
+        }
+
+        #[cfg(not(feature = "ffmpeg_3_1"))]
+        unsafe {
+            codec::Parameters::wrap((*self.as_ptr()).codec, Some(self.context.destructor()))
         }
     }
 

--- a/src/format/stream/stream_mut.rs
+++ b/src/format/stream/stream_mut.rs
@@ -49,11 +49,18 @@ impl<'a> StreamMut<'a> {
         }
     }
 
+    #[cfg(feature = "ffmpeg_3_1")]
     pub fn set_parameters<P: Into<codec::Parameters>>(&mut self, parameters: P) {
         let parameters = parameters.into();
 
+        #[cfg(feature = "ffmpeg_3_1")]
         unsafe {
             avcodec_parameters_copy((*self.as_mut_ptr()).codecpar, parameters.as_ptr());
+        }
+
+        #[cfg(not(feature = "ffmpeg_3_1"))]
+        unsafe {
+            avcodec_parameters_copy((*self.as_mut_ptr()).codec, parameters.as_ptr());
         }
     }
 

--- a/src/util/color/primaries.rs
+++ b/src/util/color/primaries.rs
@@ -18,6 +18,7 @@ pub enum Primaries {
     SMPTE428,
     SMPTE431,
     SMPTE432,
+    #[cfg(feature = "ffmpeg_4_3")]
     EBU3213,
 }
 
@@ -40,7 +41,10 @@ impl From<AVColorPrimaries> for Primaries {
             AVCOL_PRI_SMPTE428 => Primaries::SMPTE428,
             AVCOL_PRI_SMPTE431 => Primaries::SMPTE431,
             AVCOL_PRI_SMPTE432 => Primaries::SMPTE432,
+            #[cfg(feature = "ffmpeg_4_3")]
             AVCOL_PRI_EBU3213 => Primaries::EBU3213,
+            #[cfg(not(feature = "ffmpeg_4_3"))]
+            _ => unimplemented!(),
         }
     }
 }
@@ -63,6 +67,7 @@ impl Into<AVColorPrimaries> for Primaries {
             Primaries::SMPTE428 => AVCOL_PRI_SMPTE428,
             Primaries::SMPTE431 => AVCOL_PRI_SMPTE431,
             Primaries::SMPTE432 => AVCOL_PRI_SMPTE432,
+            #[cfg(feature = "ffmpeg_4_3")]
             Primaries::EBU3213 => AVCOL_PRI_EBU3213,
         }
     }

--- a/src/util/format/pixel.rs
+++ b/src/util/format/pixel.rs
@@ -1,6 +1,6 @@
 use std::{
     ffi::{CStr, CString, NulError},
-    str::{from_utf8_unchecked, FromStr}
+    str::{from_utf8_unchecked, FromStr},
 };
 
 use thiserror::Error;
@@ -49,9 +49,13 @@ pub enum Pixel {
 
     GRAY16BE,
     GRAY16LE,
+    #[cfg(feature = "ffmpeg_4_1")]
     GRAY14BE,
+    #[cfg(feature = "ffmpeg_4_1")]
     GRAY14LE,
+    #[cfg(feature = "ffmpeg_4_1")]
     GRAYF32BE,
+    #[cfg(feature = "ffmpeg_4_1")]
     GRAYF32LE,
     YUV440P,
     YUVJ440P,
@@ -168,8 +172,10 @@ pub enum Pixel {
     QSV,
     MMAL,
 
+    #[cfg(feature = "ffmpeg_3_3")]
     D3D11VA_VLD,
 
+    #[cfg(feature = "ffmpeg_3_3")]
     CUDA,
 
     ZRGB,
@@ -223,6 +229,7 @@ pub enum Pixel {
     VIDEOTOOLBOX,
 
     // --- defaults
+    #[cfg(not(feature = "ff_api_xvmc"))]
     XVMC,
 
     RGB32,
@@ -294,13 +301,16 @@ pub enum Pixel {
     GBRAP10LE,
     GBRAP10BE,
     MEDIACODEC,
+    #[cfg(feature = "ffmpeg_3_3")]
     GRAY12BE,
+    #[cfg(feature = "ffmpeg_3_3")]
     GRAY12LE,
     GRAY10BE,
     GRAY10LE,
     P016LE,
     P016BE,
 
+    #[cfg(feature = "ffmpeg_3_3")]
     D3D11,
     GRAY9BE,
     GRAY9LE,
@@ -309,6 +319,7 @@ pub enum Pixel {
     GBRAPF32BE,
     GBRAPF32LE,
     DRM_PRIME,
+    #[cfg(feature = "ffmpeg_4_0")]
     OPENCL,
 }
 
@@ -396,9 +407,13 @@ impl From<AVPixelFormat> for Pixel {
 
             AV_PIX_FMT_GRAY16BE => Pixel::GRAY16BE,
             AV_PIX_FMT_GRAY16LE => Pixel::GRAY16LE,
+            #[cfg(feature = "ffmpeg_4_1")]
             AV_PIX_FMT_GRAY14BE => Pixel::GRAY14BE,
+            #[cfg(feature = "ffmpeg_4_1")]
             AV_PIX_FMT_GRAY14LE => Pixel::GRAY14LE,
+            #[cfg(feature = "ffmpeg_4_1")]
             AV_PIX_FMT_GRAYF32BE => Pixel::GRAYF32BE,
+            #[cfg(feature = "ffmpeg_4_1")]
             AV_PIX_FMT_GRAYF32LE => Pixel::GRAYF32LE,
             AV_PIX_FMT_YUV440P => Pixel::YUV440P,
             AV_PIX_FMT_YUVJ440P => Pixel::YUVJ440P,
@@ -513,8 +528,10 @@ impl From<AVPixelFormat> for Pixel {
             AV_PIX_FMT_QSV => Pixel::QSV,
             AV_PIX_FMT_MMAL => Pixel::MMAL,
 
+            #[cfg(feature = "ffmpeg_3_3")]
             AV_PIX_FMT_D3D11VA_VLD => Pixel::D3D11VA_VLD,
 
+            #[cfg(feature = "ffmpeg_3_3")]
             AV_PIX_FMT_CUDA => Pixel::CUDA,
 
             AV_PIX_FMT_0RGB => Pixel::ZRGB,
@@ -567,6 +584,7 @@ impl From<AVPixelFormat> for Pixel {
 
             AV_PIX_FMT_VIDEOTOOLBOX => Pixel::VIDEOTOOLBOX,
 
+            #[cfg(not(feature = "ff_api_xvmc"))]
             AV_PIX_FMT_XVMC => Pixel::XVMC,
 
             AV_PIX_FMT_P010LE => Pixel::P010LE,
@@ -576,7 +594,9 @@ impl From<AVPixelFormat> for Pixel {
             AV_PIX_FMT_GBRAP10LE => Pixel::GBRAP10LE,
             AV_PIX_FMT_GBRAP10BE => Pixel::GBRAP10BE,
             AV_PIX_FMT_MEDIACODEC => Pixel::MEDIACODEC,
+            #[cfg(feature = "ffmpeg_3_3")]
             AV_PIX_FMT_GRAY12BE => Pixel::GRAY12BE,
+            #[cfg(feature = "ffmpeg_3_3")]
             AV_PIX_FMT_GRAY12LE => Pixel::GRAY12LE,
             AV_PIX_FMT_GRAY10BE => Pixel::GRAY10BE,
             AV_PIX_FMT_GRAY10LE => Pixel::GRAY10LE,
@@ -585,6 +605,7 @@ impl From<AVPixelFormat> for Pixel {
 
             AV_PIX_FMT_NB => Pixel::None,
 
+            #[cfg(feature = "ffmpeg_3_3")]
             AV_PIX_FMT_D3D11 => Pixel::D3D11,
             AV_PIX_FMT_GRAY9BE => Pixel::GRAY9BE,
             AV_PIX_FMT_GRAY9LE => Pixel::GRAY9LE,
@@ -593,6 +614,7 @@ impl From<AVPixelFormat> for Pixel {
             AV_PIX_FMT_GBRAPF32BE => Pixel::GBRAPF32BE,
             AV_PIX_FMT_GBRAPF32LE => Pixel::GBRAPF32LE,
             AV_PIX_FMT_DRM_PRIME => Pixel::DRM_PRIME,
+            #[cfg(feature = "ffmpeg_4_0")]
             AV_PIX_FMT_OPENCL => Pixel::OPENCL,
 
             _ => unimplemented!(),
@@ -643,9 +665,13 @@ impl Into<AVPixelFormat> for Pixel {
 
             Pixel::GRAY16BE => AV_PIX_FMT_GRAY16BE,
             Pixel::GRAY16LE => AV_PIX_FMT_GRAY16LE,
+            #[cfg(feature = "ffmpeg_4_1")]
             Pixel::GRAY14BE => AV_PIX_FMT_GRAY14BE,
+            #[cfg(feature = "ffmpeg_4_1")]
             Pixel::GRAY14LE => AV_PIX_FMT_GRAY14LE,
+            #[cfg(feature = "ffmpeg_4_1")]
             Pixel::GRAYF32BE => AV_PIX_FMT_GRAYF32BE,
+            #[cfg(feature = "ffmpeg_4_1")]
             Pixel::GRAYF32LE => AV_PIX_FMT_GRAYF32LE,
             Pixel::YUV440P => AV_PIX_FMT_YUV440P,
             Pixel::YUVJ440P => AV_PIX_FMT_YUVJ440P,
@@ -762,8 +788,10 @@ impl Into<AVPixelFormat> for Pixel {
             Pixel::QSV => AV_PIX_FMT_QSV,
             Pixel::MMAL => AV_PIX_FMT_MMAL,
 
+            #[cfg(feature = "ffmpeg_3_3")]
             Pixel::D3D11VA_VLD => AV_PIX_FMT_D3D11VA_VLD,
 
+            #[cfg(feature = "ffmpeg_3_3")]
             Pixel::CUDA => AV_PIX_FMT_CUDA,
 
             Pixel::ZRGB => AV_PIX_FMT_0RGB,
@@ -817,6 +845,7 @@ impl Into<AVPixelFormat> for Pixel {
             Pixel::VIDEOTOOLBOX => AV_PIX_FMT_VIDEOTOOLBOX,
 
             // --- defaults
+            #[cfg(not(feature = "ff_api_xvmc"))]
             Pixel::XVMC => AV_PIX_FMT_XVMC,
 
             Pixel::RGB32 => AV_PIX_FMT_RGB32,
@@ -888,13 +917,16 @@ impl Into<AVPixelFormat> for Pixel {
             Pixel::GBRAP10LE => AV_PIX_FMT_GBRAP10LE,
             Pixel::GBRAP10BE => AV_PIX_FMT_GBRAP10BE,
             Pixel::MEDIACODEC => AV_PIX_FMT_MEDIACODEC,
+            #[cfg(feature = "ffmpeg_3_3")]
             Pixel::GRAY12BE => AV_PIX_FMT_GRAY12BE,
+            #[cfg(feature = "ffmpeg_3_3")]
             Pixel::GRAY12LE => AV_PIX_FMT_GRAY12LE,
             Pixel::GRAY10BE => AV_PIX_FMT_GRAY10BE,
             Pixel::GRAY10LE => AV_PIX_FMT_GRAY10LE,
             Pixel::P016LE => AV_PIX_FMT_P016LE,
             Pixel::P016BE => AV_PIX_FMT_P016BE,
 
+            #[cfg(feature = "ffmpeg_3_3")]
             Pixel::D3D11 => AV_PIX_FMT_D3D11,
             Pixel::GRAY9BE => AV_PIX_FMT_GRAY9BE,
             Pixel::GRAY9LE => AV_PIX_FMT_GRAY9LE,
@@ -903,6 +935,7 @@ impl Into<AVPixelFormat> for Pixel {
             Pixel::GBRAPF32BE => AV_PIX_FMT_GBRAPF32BE,
             Pixel::GBRAPF32LE => AV_PIX_FMT_GBRAPF32LE,
             Pixel::DRM_PRIME => AV_PIX_FMT_DRM_PRIME,
+            #[cfg(feature = "ffmpeg_4_0")]
             Pixel::OPENCL => AV_PIX_FMT_OPENCL,
         }
     }

--- a/src/util/frame/mod.rs
+++ b/src/util/frame/mod.rs
@@ -11,8 +11,8 @@ pub mod flag;
 pub use self::flag::Flags;
 
 use crate::ffi::*;
-use libc::c_int;
 use crate::{Dictionary, DictionaryRef};
+use libc::c_int;
 
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub struct Packet {
@@ -80,6 +80,19 @@ impl Frame {
 
     #[inline]
     pub fn packet(&self) -> Packet {
+        #[cfg(feature = "ffmpeg_3_2")]
+        unsafe {
+            Packet {
+                duration: av_frame_get_pkt_duration(self.as_ptr()) as i64,
+                position: av_frame_get_pkt_pos(self.as_ptr()) as i64,
+                size: av_frame_get_pkt_size(self.as_ptr()) as usize,
+
+                pts: (*self.as_ptr()).pts,
+                dts: (*self.as_ptr()).pkt_dts,
+            }
+        }
+
+        #[cfg(not(feature = "ffmpeg_3_2"))]
         unsafe {
             Packet {
                 duration: av_frame_get_pkt_duration(self.as_ptr()) as i64,

--- a/src/util/frame/side_data.rs
+++ b/src/util/frame/side_data.rs
@@ -23,14 +23,20 @@ pub enum Type {
     AudioServiceType,
     MasteringDisplayMetadata,
     GOPTimecode,
+    #[cfg(feature = "ffmpeg_3_3")]
     Spherical,
 
+    #[cfg(feature = "ffmpeg_3_3")]
     ContentLightLevel,
+    #[cfg(feature = "ffmpeg_3_4")]
     IccProfile,
 
+    #[cfg(feature = "ffmpeg_4_0")]
     QpTableProperties,
+    #[cfg(feature = "ffmpeg_4_0")]
     QpTableData,
 
+    #[cfg(feature = "ffmpeg_4_1")]
     S12MTimecode,
 }
 
@@ -61,13 +67,19 @@ impl From<AVFrameSideDataType> for Type {
             AV_FRAME_DATA_AUDIO_SERVICE_TYPE => Type::AudioServiceType,
             AV_FRAME_DATA_MASTERING_DISPLAY_METADATA => Type::MasteringDisplayMetadata,
             AV_FRAME_DATA_GOP_TIMECODE => Type::GOPTimecode,
+            #[cfg(feature = "ffmpeg_3_3")]
             AV_FRAME_DATA_SPHERICAL => Type::Spherical,
 
+            #[cfg(feature = "ffmpeg_3_3")]
             AV_FRAME_DATA_CONTENT_LIGHT_LEVEL => Type::ContentLightLevel,
+            #[cfg(feature = "ffmpeg_3_4")]
             AV_FRAME_DATA_ICC_PROFILE => Type::IccProfile,
             // TODO It's undef #if in frame.h
+            #[cfg(feature = "ffmpeg_4_0")]
             AV_FRAME_DATA_QP_TABLE_PROPERTIES => Type::QpTableProperties,
+            #[cfg(feature = "ffmpeg_4_0")]
             AV_FRAME_DATA_QP_TABLE_DATA => Type::QpTableData,
+            #[cfg(feature = "ffmpeg_4_1")]
             AV_FRAME_DATA_S12M_TIMECODE => Type::S12MTimecode,
 
             _ => unimplemented!(),
@@ -92,14 +104,20 @@ impl Into<AVFrameSideDataType> for Type {
             Type::AudioServiceType => AV_FRAME_DATA_AUDIO_SERVICE_TYPE,
             Type::MasteringDisplayMetadata => AV_FRAME_DATA_MASTERING_DISPLAY_METADATA,
             Type::GOPTimecode => AV_FRAME_DATA_GOP_TIMECODE,
+            #[cfg(feature = "ffmpeg_3_3")]
             Type::Spherical => AV_FRAME_DATA_SPHERICAL,
 
+            #[cfg(feature = "ffmpeg_3_3")]
             Type::ContentLightLevel => AV_FRAME_DATA_CONTENT_LIGHT_LEVEL,
+            #[cfg(feature = "ffmpeg_3_4")]
             Type::IccProfile => AV_FRAME_DATA_ICC_PROFILE,
 
+            #[cfg(feature = "ffmpeg_4_0")]
             Type::QpTableProperties => AV_FRAME_DATA_QP_TABLE_PROPERTIES,
+            #[cfg(feature = "ffmpeg_4_0")]
             Type::QpTableData => AV_FRAME_DATA_QP_TABLE_DATA,
 
+            #[cfg(feature = "ffmpeg_4_1")]
             Type::S12MTimecode => AV_FRAME_DATA_S12M_TIMECODE,
         }
     }


### PR DESCRIPTION
Currently, this crate will fail to compile if an older
version of the ffmpeg libraries are installed on the machine.
This change causes this crate to support FFMpeg 3.0 and newer
by default. Newer API features can be enabled by setting the
appropriate feature flag e.g. `ffmpeg_3_4`, although this
will cause the crate using this crate to fail to compile on
older versions of ffmpeg.

Most immediately, this is required for CI on
https://github.com/rust-av/av-metrics/pull/218 to function correctly,
as Github Actions includes Ubuntu Bionic, which only includes up to FFMpeg 3.4.

Closes #136