### PR TITLE
Fixes compile error caused by Flag without serde

### DIFF
--- a/src/software/resampling/mod.rs
+++ b/src/software/resampling/mod.rs
@@ -1,4 +1,5 @@
 pub mod flag;
+#[cfg(feature = "serde")]
 pub use self::flag::Flags;
 
 pub mod dither;


### PR DESCRIPTION
If the serde feature isn't enabled then Flag doesn't exist and the crate doesn't compile successfully. This PR fixes it by applying the same feature requirement on the public reexport of Flag in the mod.rs