### PR TITLE
Fix issue with accessing all samples in packed dual channel audio

### DIFF
--- a/src/util/frame/audio.rs
+++ b/src/util/frame/audio.rs
@@ -148,12 +148,13 @@ impl Audio {
 		if !<T as Sample>::is_valid(self.format(), self.channels()) {
 			panic!("unsupported type");
 		}
-        
-        let len = if self.is_packed() {
-            self.samples() * self.channels() as usize
-        } else {
-            self.samples()
-        };
+
+		let len = if self.is_packed() {
+			self.samples() * self.channels() as usize
+		}
+		else {
+			self.samples()
+		};
 		unsafe { slice::from_raw_parts((*self.as_ptr()).data[index] as *const T, len) }
 	}
 
@@ -167,11 +168,12 @@ impl Audio {
 			panic!("unsupported type");
 		}
 
-        let len = if self.is_packed() {
-            self.samples() * self.channels() as usize
-        } else {
-            self.samples()
-        };
+		let len = if self.is_packed() {
+			self.samples() * self.channels() as usize
+		}
+		else {
+			self.samples()
+		};
 		unsafe { slice::from_raw_parts_mut((*self.as_mut_ptr()).data[index] as *mut T, len) }
 	}
 

--- a/src/util/frame/audio.rs
+++ b/src/util/frame/audio.rs
@@ -148,8 +148,13 @@ impl Audio {
 		if !<T as Sample>::is_valid(self.format(), self.channels()) {
 			panic!("unsupported type");
 		}
-
-		unsafe { slice::from_raw_parts((*self.as_ptr()).data[index] as *const T, self.samples()) }
+        
+        let len = if self.is_packed() {
+            self.samples() * self.channels() as usize
+        } else {
+            self.samples()
+        };
+		unsafe { slice::from_raw_parts((*self.as_ptr()).data[index] as *const T, len) }
 	}
 
 	#[inline]
@@ -162,7 +167,12 @@ impl Audio {
 			panic!("unsupported type");
 		}
 
-		unsafe { slice::from_raw_parts_mut((*self.as_mut_ptr()).data[index] as *mut T, self.samples()) }
+        let len = if self.is_packed() {
+            self.samples() * self.channels() as usize
+        } else {
+            self.samples()
+        };
+		unsafe { slice::from_raw_parts_mut((*self.as_mut_ptr()).data[index] as *mut T, len) }
 	}
 
 	#[inline]


### PR DESCRIPTION
So nb_samples in AVFrame is independent of channels, and for planar audio data the current code which uses `samples()` to set the slice length works perfectly. However for packed data where it's in the form `[channel[0], channel[1], channel[0], channel[1]]` the samples slice truncates the last 50% of the samples for stereo data.

To test this worked I took my own audio sample extraction code that works against mono audio using these bindings (tests done by transcoding to wav and comparing bytes with ffmpeg running on the file via CLI). In the screenshot below we can see:

1. The input stereo file 
2. Current master extracting just channel 1
3. Current master extracting just channel 2
4. This PR extracting just channel 1
5. This PR extracting just channel 2

![Screenshot from 2021-07-16 16-44-50](https://user-images.githubusercontent.com/3472518/125974379-488b2ff6-9b74-40f7-b6b2-cf5940633801.png)

If you want to test on some files of your own this is my code to extract a vec of samples from a  `util::frame::Audio`

```rust
#[inline]
pub(crate) fn get_samples<T: Sample + Copy>(audio: &Audio) -> Vec<Samples<T>> {
    let mut res = vec![];
    trace!("audio: {:?}", audio);
    for channel in 0..audio.channels() {
        let samples = audio
            .plane::<T>(0)
            .iter()
            .skip(channel as usize)
            .step_by(audio.channels() as usize)
            .copied()
            .collect::<Vec<T>>();
        res.push(Samples {
            channel: channel as usize,
            samples,
        });
    }
    res
}
```