### PR TITLE
fix resampling::Context flush documentation

### DIFF
--- a/src/software/resampling/context.rs
+++ b/src/software/resampling/context.rs
@@ -76,8 +76,7 @@ impl Context {
 						},
 					}),
 				}
-			}
-			else {
+			} else {
 				Err(Error::InvalidData)
 			}
 		}
@@ -133,7 +132,9 @@ impl Context {
 
 	/// Convert one of the remaining internal frames.
 	///
-	/// When there are no more internal frames `Ok(None)` will be returned.
+	/// Must be called with a valid non-Empty [Audio](frame::Audio) (rate, format, and
+	/// channel_layout correctly set).
+	/// When there are no more internal frames, `output.samples() == 0`.
 	pub fn flush(&mut self, output: &mut frame::Audio) -> Result<Option<Delay>, Error> {
 		output.set_rate(self.output.rate);
 


### PR DESCRIPTION
In the interest of not making a backwards-incompatible change to the api -- here's a documentation fix for `flush`.

If a version bump is on the table, I would probably propose removing `Delay` from the return value and either returning `Ok(output.samples())` (where `Ok(0)` is the finished case), or just `Ok(())` and let the user check the output buffer.

Addresses https://github.com/meh/rust-ffmpeg/issues/162