### PR TITLE
Implement Send for swscale Context struct

### DIFF
--- a/src/software/scaling/context.rs
+++ b/src/software/scaling/context.rs
@@ -168,3 +168,5 @@ impl Drop for Context {
 		}
 	}
 }
+
+unsafe impl Send for Context {}


### PR DESCRIPTION
As far as I can tell, swscale's `SwsContext` can be sent between threads, it doesn't have any thread-local state.

This allows using swscale in async functions.