### PR TITLE
fix(resampling): use larger get_delay base

### DIFF
--- a/src/software/resampling/context.rs
+++ b/src/software/resampling/context.rs
@@ -3,7 +3,12 @@ use std::ptr;
 use libc::c_int;
 
 use super::Delay;
-use crate::{ffi::*, frame, util::format, ChannelLayout, Error};
+use crate::{
+	ffi::*,
+	frame,
+	util::{format, mathematics::rescale::TIME_BASE},
+	ChannelLayout, Error,
+};
 
 #[derive(Eq, PartialEq, Copy, Clone)]
 pub struct Definition {
@@ -96,7 +101,7 @@ impl Context {
 	/// Get the remaining delay.
 	pub fn delay(&self) -> Option<Delay> {
 		unsafe {
-			match swr_get_delay(self.as_ptr() as *mut _, 1) {
+			match swr_get_delay(self.as_ptr() as *mut _, TIME_BASE.1 as i64) {
 				0 => None,
 				_ => Some(Delay::from(self)),
 			}


### PR DESCRIPTION
With the previous base of 1, get_delay will return the delay in seconds.
Given the much smaller time deltas involved in audio resampling, it's
possible that it would round down to 0 in most cases, and the
rust-ffmpeg would pretend there is no delay.

**Warning**: I'm not sure this is actually an improvement, since I can't seem to get `get_delay` to return anything non-zero. Consider it more of a suggestion than a "please pull this". :)