### PR TITLE
feat(frame): allow deconstruction of type-specific frames

### DIFF
--- a/src/util/frame/audio.rs
+++ b/src/util/frame/audio.rs
@@ -10,7 +10,7 @@ use super::Frame;
 use crate::{ffi::*, util::format, ChannelLayout};
 
 #[derive(PartialEq, Eq)]
-pub struct Audio(Frame);
+pub struct Audio(pub Frame);
 
 impl Audio {
 	#[inline(always)]

--- a/src/util/frame/video.rs
+++ b/src/util/frame/video.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 #[derive(PartialEq, Eq)]
-pub struct Video(Frame);
+pub struct Video(pub Frame);
 
 impl Video {
 	#[inline(always)]


### PR DESCRIPTION
This pattern is already present for the audio/video type-specific en-/decoders, and is necessary to call e.g. `Video::set_kind` to set `pict_type` when working with generic frames. The alternative would be to expose that setter on the generic frame, but that goes counter to having them separated by media type in the first place.