### PR TITLE
Fix segfault reading input packet stream (compiler type layout change?)

### DIFF
--- a/src/format/chapter/chapter_mut.rs
+++ b/src/format/chapter/chapter_mut.rs
@@ -15,10 +15,10 @@ pub struct ChapterMut<'a> {
 impl<'a> ChapterMut<'a> {
 	pub unsafe fn wrap(context: &mut Context, index: usize) -> ChapterMut<'_> {
 		ChapterMut {
-			context: mem::transmute_copy(&context),
+			context: mem::transmute::<&mut Context, &mut Context>(context),
 			index,
 
-			immutable: Chapter::wrap(mem::transmute_copy(&context), index),
+			immutable: Chapter::wrap(mem::transmute::<&Context, &Context>(context), index),
 		}
 	}
 

--- a/src/format/context/common.rs
+++ b/src/format/context/common.rs
@@ -274,7 +274,7 @@ impl<'a> Iterator for StreamIterMut<'a> {
 
 		unsafe {
 			Some(StreamMut::wrap(
-				mem::transmute_copy(&self.context),
+				mem::transmute::<&mut Context, &mut Context>(self.context),
 				(self.current - 1) as usize,
 			))
 		}
@@ -349,7 +349,7 @@ impl<'a> Iterator for ChapterIterMut<'a> {
 			self.current += 1;
 
 			Some(ChapterMut::wrap(
-				mem::transmute_copy(&self.context),
+				mem::transmute::<&mut Context, &mut Context>(self.context),
 				(self.current - 1) as usize,
 			))
 		}

--- a/src/format/context/input.rs
+++ b/src/format/context/input.rs
@@ -181,10 +181,10 @@ impl<'a> Iterator for PacketIter<'a> {
 			Err(Error::Eof) => None,
 
 			Ok(..) => unsafe {
-				Some(Ok((
-					Stream::wrap(mem::transmute_copy(&self.context), packet.stream()),
-					packet,
-				)))
+				let context = mem::transmute::<&Context, &Context>(self.context);
+				let stream = Stream::wrap(context, packet.stream());
+
+				Some(Ok((stream, packet)))
 			},
 
 			Err(err) => Some(Err(err)),

--- a/src/format/stream/stream_mut.rs
+++ b/src/format/stream/stream_mut.rs
@@ -13,10 +13,10 @@ pub struct StreamMut<'a> {
 impl<'a> StreamMut<'a> {
 	pub unsafe fn wrap(context: &mut Context, index: usize) -> StreamMut<'_> {
 		StreamMut {
-			context: mem::transmute_copy(&context),
+			context: mem::transmute::<&mut Context, &mut Context>(context),
 			index,
 
-			immutable: Stream::wrap(mem::transmute_copy(&context), index),
+			immutable: Stream::wrap(mem::transmute::<&Context, &Context>(context), index),
 		}
 	}
 


### PR DESCRIPTION
* Fixes #176 (see linked issue for a description of what I think the problem there was.)
* Adds an explicit `copy_for_wrap()` function to avoid the possibility that `transmute_copy()` has input or return types other than `Context`.

I'm not that comfortable with unsafe Rust or libavcodec, but hopefully this works as expected. :)