### PR TITLE
Fix CI, fix or workaround build errors pre-FFmpeg 6.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,11 +11,17 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-24.04  # "noble", ffmpeg 6.1
+            ffmpeg_feature: "ffmpeg_6_0"
+          - os: ubuntu-22.04  # "jammy", ffmpeg 4.4
+            ffmpeg_feature: "ffmpeg_4_4"
+    runs-on: ${{ matrix.os }}
     steps:
-    - name: Install ffmpeg
-      run: sudo apt-get -y install ffmpeg pkg-config libavutil-dev libavformat-dev libavfilter-dev libavdevice-dev
-    - uses: actions/checkout@v4
-    - name: Run tests
-      run: cargo test --all --verbose --features=ffmpeg_4_4
+      - name: Install ffmpeg
+        run: sudo apt-get -y install ffmpeg pkg-config libavutil-dev libavformat-dev libavfilter-dev libavdevice-dev
+      - uses: actions/checkout@v4
+      - name: Run tests
+        run: cargo test --all --verbose --features=${{ matrix.ffmpeg_feature }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,8 @@
 name: Tests
 
 on:
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
+  - push
+  - pull_request
 
 env:
   CARGO_TERM_COLOR: always

--- a/examples/codec-info.rs
+++ b/examples/codec-info.rs
@@ -46,15 +46,18 @@ fn print_codec(codec: Codec) {
 			println!("\t formats: any");
 		}
 
-		if let Some(layouts) = audio.channel_layouts() {
-			println!("\t channel_layouts:");
-			for layout in layouts {
-				println!("\t\t {}", layout.describe().unwrap());
-			}
-		}
-		else {
-			println!("\t channel_layouts: any");
-		}
+        #[cfg(feature = "ffmpeg_6_0")]
+        {
+		    if let Some(layouts) = audio.channel_layouts() {
+			    println!("\t channel_layouts:");
+			    for layout in layouts {
+				    println!("\t\t {}", layout.describe().unwrap());
+			    }
+		    }
+		    else {
+			    println!("\t channel_layouts: any");
+		    }
+        }
 	}
 
 	println!("\t max_lowres: {:?}", codec.max_lowres());

--- a/examples/metadata.rs
+++ b/examples/metadata.rs
@@ -85,6 +85,7 @@ fn main() {
 						println!("\taudio.format: {:?}", audio.format());
 						println!("\taudio.frames: {}", audio.frames());
 						println!("\taudio.align: {}", audio.align());
+						#[cfg(feature = "ffmpeg_6_0")]
 						println!("\taudio.channel_layout: {:?}", audio.channel_layout());
 					}
 				}

--- a/src/codec/audio.rs
+++ b/src/codec/audio.rs
@@ -33,6 +33,7 @@ impl Audio {
 		}
 	}
 
+    #[cfg(feature = "ffmpeg_6_0")]
 	pub fn channel_layouts(&self) -> Option<ChannelLayoutIter> {
 		unsafe {
 			(!(*self.codec.as_ptr()).ch_layouts.is_null()).then(|| ChannelLayoutIter {
@@ -99,11 +100,13 @@ impl Iterator for FormatIter<'_> {
 	}
 }
 
+#[cfg(feature = "ffmpeg_6_0")]
 pub struct ChannelLayoutIter<'a> {
 	inner: &'a Audio,
 	next_idx: isize,
 }
 
+#[cfg(feature = "ffmpeg_6_0")]
 impl ChannelLayoutIter<'_> {
 	pub fn best(self, max: i32) -> ChannelLayout {
 		self.fold(crate::channel_layout::ChannelLayout::MONO, |acc, cur| {
@@ -117,6 +120,7 @@ impl ChannelLayoutIter<'_> {
 	}
 }
 
+#[cfg(feature = "ffmpeg_6_0")]
 impl Iterator for ChannelLayoutIter<'_> {
 	type Item = ChannelLayout;
 

--- a/src/codec/decoder/audio.rs
+++ b/src/codec/decoder/audio.rs
@@ -32,10 +32,12 @@ impl Audio {
 		unsafe { (*self.as_ptr()).block_align as usize }
 	}
 
+	#[cfg(feature = "ffmpeg_6_0")]
 	pub fn channel_layout(&self) -> ChannelLayout {
 		unsafe { (*self.as_ptr()).ch_layout.into() }
 	}
 
+	#[cfg(feature = "ffmpeg_6_0")]
 	pub fn set_channel_layout(&mut self, value: ChannelLayout) {
 		unsafe {
 			(*self.as_mut_ptr()).ch_layout = value.into();

--- a/src/codec/encoder/audio.rs
+++ b/src/codec/encoder/audio.rs
@@ -92,12 +92,14 @@ impl Audio {
 		unsafe { format::Sample::from((*self.as_ptr()).sample_fmt) }
 	}
 
+	#[cfg(feature = "ffmpeg_6_0")]
 	pub fn set_channel_layout(&mut self, value: ChannelLayout) {
 		unsafe {
 			(*self.as_mut_ptr()).ch_layout = value.into();
 		}
 	}
 
+	#[cfg(feature = "ffmpeg_6_0")]
 	pub fn channel_layout(&self) -> ChannelLayout {
 		unsafe { (*self.as_ptr()).ch_layout.into() }
 	}

--- a/src/codec/packet/packet.rs
+++ b/src/codec/packet/packet.rs
@@ -107,13 +107,13 @@ impl Packet {
 	}
 
 	#[inline]
-    #[cfg(feature = "ffmpeg_5_0")]
+	#[cfg(feature = "ffmpeg_5_0")]
 	pub fn time_base(&self) -> Option<Rational> {
 		Rational::from(self.0.time_base).non_zero()
 	}
 
 	#[inline]
-    #[cfg(feature = "ffmpeg_5_0")]
+	#[cfg(feature = "ffmpeg_5_0")]
 	pub fn set_time_base(&mut self, time_base: Option<impl Into<Rational>>) {
 		self.0.time_base = time_base.map(Into::into).unwrap_or(Rational::ZERO).into();
 	}
@@ -257,13 +257,13 @@ impl Packet {
 	}
 
 	#[inline]
-    #[cfg(feature = "ffmpeg_5_0")]
+	#[cfg(feature = "ffmpeg_5_0")]
 	pub fn opaque(&self) -> *mut c_void {
 		unsafe { (*self.as_ptr()).opaque }
 	}
 
 	#[inline]
-    #[cfg(feature = "ffmpeg_5_0")]
+	#[cfg(feature = "ffmpeg_5_0")]
 	pub fn set_opaque(&mut self, data: *mut c_void) {
 		unsafe {
 			(*self.as_mut_ptr()).opaque = data;

--- a/src/codec/packet/packet.rs
+++ b/src/codec/packet/packet.rs
@@ -107,11 +107,13 @@ impl Packet {
 	}
 
 	#[inline]
+    #[cfg(feature = "ffmpeg_5_0")]
 	pub fn time_base(&self) -> Option<Rational> {
 		Rational::from(self.0.time_base).non_zero()
 	}
 
 	#[inline]
+    #[cfg(feature = "ffmpeg_5_0")]
 	pub fn set_time_base(&mut self, time_base: Option<impl Into<Rational>>) {
 		self.0.time_base = time_base.map(Into::into).unwrap_or(Rational::ZERO).into();
 	}
@@ -255,11 +257,13 @@ impl Packet {
 	}
 
 	#[inline]
+    #[cfg(feature = "ffmpeg_5_0")]
 	pub fn opaque(&self) -> *mut c_void {
 		unsafe { (*self.as_ptr()).opaque }
 	}
 
 	#[inline]
+    #[cfg(feature = "ffmpeg_5_0")]
 	pub fn set_opaque(&mut self, data: *mut c_void) {
 		unsafe {
 			(*self.as_mut_ptr()).opaque = data;

--- a/src/device/input.rs
+++ b/src/device/input.rs
@@ -9,7 +9,11 @@ impl Iterator for AudioIter {
 
 	fn next(&mut self) -> Option<<Self as Iterator>::Item> {
 		unsafe {
+            #[cfg(feature = "ffmpeg_5_0")]
 			let ptr = av_input_audio_device_next(self.0);
+
+            #[cfg(not(feature = "ffmpeg_5_0"))]
+			let ptr = av_input_audio_device_next(self.0.cast_mut());
 
 			if ptr.is_null() && !self.0.is_null() {
 				None
@@ -34,7 +38,11 @@ impl Iterator for VideoIter {
 
 	fn next(&mut self) -> Option<<Self as Iterator>::Item> {
 		unsafe {
+            #[cfg(feature = "ffmpeg_5_0")]
 			let ptr = av_input_video_device_next(self.0);
+
+            #[cfg(not(feature = "ffmpeg_5_0"))]
+			let ptr = av_input_video_device_next(self.0.cast_mut());
 
 			if ptr.is_null() && !self.0.is_null() {
 				None

--- a/src/device/input.rs
+++ b/src/device/input.rs
@@ -9,10 +9,10 @@ impl Iterator for AudioIter {
 
 	fn next(&mut self) -> Option<<Self as Iterator>::Item> {
 		unsafe {
-            #[cfg(feature = "ffmpeg_5_0")]
+			#[cfg(feature = "ffmpeg_5_0")]
 			let ptr = av_input_audio_device_next(self.0);
 
-            #[cfg(not(feature = "ffmpeg_5_0"))]
+			#[cfg(not(feature = "ffmpeg_5_0"))]
 			let ptr = av_input_audio_device_next(self.0.cast_mut());
 
 			if ptr.is_null() && !self.0.is_null() {

--- a/src/device/output.rs
+++ b/src/device/output.rs
@@ -9,10 +9,10 @@ impl Iterator for AudioIter {
 
 	fn next(&mut self) -> Option<<Self as Iterator>::Item> {
 		unsafe {
-            #[cfg(feature = "ffmpeg_5_0")]
+			#[cfg(feature = "ffmpeg_5_0")]
 			let ptr = av_output_audio_device_next(self.0);
 
-            #[cfg(not(feature = "ffmpeg_5_0"))]
+			#[cfg(not(feature = "ffmpeg_5_0"))]
 			let ptr = av_output_audio_device_next(self.0.cast_mut());
 
 			if ptr.is_null() && !self.0.is_null() {
@@ -38,10 +38,10 @@ impl Iterator for VideoIter {
 
 	fn next(&mut self) -> Option<<Self as Iterator>::Item> {
 		unsafe {
-            #[cfg(feature = "ffmpeg_5_0")]
+			#[cfg(feature = "ffmpeg_5_0")]
 			let ptr = av_output_video_device_next(self.0);
 
-            #[cfg(not(feature = "ffmpeg_5_0"))]
+			#[cfg(not(feature = "ffmpeg_5_0"))]
 			let ptr = av_output_video_device_next(self.0.cast_mut());
 
 			if ptr.is_null() && !self.0.is_null() {

--- a/src/device/output.rs
+++ b/src/device/output.rs
@@ -9,7 +9,11 @@ impl Iterator for AudioIter {
 
 	fn next(&mut self) -> Option<<Self as Iterator>::Item> {
 		unsafe {
+            #[cfg(feature = "ffmpeg_5_0")]
 			let ptr = av_output_audio_device_next(self.0);
+
+            #[cfg(not(feature = "ffmpeg_5_0"))]
+			let ptr = av_output_audio_device_next(self.0.cast_mut());
 
 			if ptr.is_null() && !self.0.is_null() {
 				None
@@ -34,7 +38,11 @@ impl Iterator for VideoIter {
 
 	fn next(&mut self) -> Option<<Self as Iterator>::Item> {
 		unsafe {
+            #[cfg(feature = "ffmpeg_5_0")]
 			let ptr = av_output_video_device_next(self.0);
+
+            #[cfg(not(feature = "ffmpeg_5_0"))]
+			let ptr = av_output_video_device_next(self.0.cast_mut());
 
 			if ptr.is_null() && !self.0.is_null() {
 				None

--- a/src/filter/filter.rs
+++ b/src/filter/filter.rs
@@ -43,11 +43,17 @@ impl Filter {
 		unsafe {
 			let ptr = (*self.as_ptr()).inputs;
 
+			#[cfg(feature = "ffmpeg_5_0")]
+			let count = (*self.as_ptr()).nb_inputs;
+
+			#[cfg(not(feature = "ffmpeg_5_0"))]
+			let count = avfilter_pad_count((*self.as_ptr()).inputs);
+
 			if ptr.is_null() {
 				None
 			}
 			else {
-				Some(PadIter::new(ptr, (*self.as_ptr()).nb_inputs as usize))
+				Some(PadIter::new(ptr, count as usize))
 			}
 		}
 	}
@@ -56,11 +62,17 @@ impl Filter {
 		unsafe {
 			let ptr = (*self.as_ptr()).outputs;
 
+			#[cfg(feature = "ffmpeg_5_0")]
+			let count = (*self.as_ptr()).nb_outputs;
+
+			#[cfg(not(feature = "ffmpeg_5_0"))]
+			let count = avfilter_pad_count((*self.as_ptr()).outputs);
+
 			if ptr.is_null() {
 				None
 			}
 			else {
-				Some(PadIter::new(ptr, (*self.as_ptr()).nb_outputs as usize))
+				Some(PadIter::new(ptr, count as usize))
 			}
 		}
 	}

--- a/src/format/chapter/chapter.rs
+++ b/src/format/chapter/chapter.rs
@@ -1,5 +1,11 @@
 use crate::{ffi::*, format::context::common::Context, DictionaryRef, Rational};
 
+#[cfg(feature = "ffmpeg_5_0")]
+pub type ChapterId = i64;
+
+#[cfg(not(feature = "ffmpeg_5_0"))]
+pub type ChapterId = i32;
+
 // WARNING: index refers to the offset in the chapters array (starting from 0)
 // it is not necessarly equal to the id (which may start at 1)
 pub struct Chapter<'a> {
@@ -22,7 +28,7 @@ impl<'a> Chapter<'a> {
 		self.index
 	}
 
-	pub fn id(&self) -> i64 {
+	pub fn id(&self) -> ChapterId {
 		unsafe { (*self.as_ptr()).id }
 	}
 

--- a/src/format/chapter/chapter_mut.rs
+++ b/src/format/chapter/chapter_mut.rs
@@ -1,6 +1,6 @@
 use std::{mem, ops::Deref};
 
-use super::Chapter;
+use super::{ChapterId, Chapter};
 use crate::{ffi::*, format::context::common::Context, Dictionary, DictionaryMut, Rational};
 
 // WARNING: index refers to the offset in the chapters array (starting from 0)
@@ -28,7 +28,7 @@ impl<'a> ChapterMut<'a> {
 }
 
 impl<'a> ChapterMut<'a> {
-	pub fn set_id(&mut self, value: i64) {
+	pub fn set_id(&mut self, value: ChapterId) {
 		unsafe {
 			(*self.as_mut_ptr()).id = value;
 		}

--- a/src/format/chapter/mod.rs
+++ b/src/format/chapter/mod.rs
@@ -1,5 +1,6 @@
 mod chapter;
 pub use self::chapter::Chapter;
+pub use self::chapter::ChapterId;
 
 mod chapter_mut;
 pub use self::chapter_mut::ChapterMut;

--- a/src/format/context/common.rs
+++ b/src/format/context/common.rs
@@ -172,13 +172,18 @@ impl<'a> Best<'a> {
 		'a: 'b,
 	{
 		unsafe {
+            #[cfg(feature = "ffmpeg_5_0")]
 			let mut decoder = ptr::null::<AVCodec>();
+
+            #[cfg(not(feature = "ffmpeg_5_0"))]
+			let mut decoder = ptr::null_mut::<AVCodec>();
+
 			let index = av_find_best_stream(
 				self.context.ptr,
 				kind.into(),
 				self.wanted as c_int,
 				self.related as c_int,
-				&mut decoder as *mut _,
+                &mut decoder as *mut _,
 				0,
 			);
 

--- a/src/format/context/output.rs
+++ b/src/format/context/output.rs
@@ -11,7 +11,7 @@ use super::{common::Context, destructor};
 use crate::{
 	ffi::*,
 	format::{self, io::Io},
-	ChapterMut, Dictionary, Error, Rational, StreamMut,
+	ChapterId, ChapterMut, Dictionary, Error, Rational, StreamMut,
 };
 
 pub struct Output {
@@ -116,7 +116,7 @@ impl Output {
 
 	pub fn add_chapter<R: Into<Rational>, S: AsRef<str>>(
 		&mut self,
-		id: i64,
+		id: ChapterId,
 		time_base: R,
 		start: i64,
 		end: i64,

--- a/src/format/format/input.rs
+++ b/src/format/format/input.rs
@@ -20,6 +20,23 @@ impl Input {
 	pub unsafe fn as_ptr(&self) -> *const AVInputFormat {
 		self.ptr
 	}
+
+    #[cfg(not(feature = "ffmpeg_5_0"))]
+    pub unsafe fn as_mut_ptr(&mut self) -> *mut AVInputFormat {
+		self.ptr.cast_mut()
+    }
+
+    // Some APIs const-ified args in FFMPEG 5.0:
+
+    #[cfg(not(feature = "ffmpeg_5_0"))]
+    pub(crate) unsafe fn as_api_ptr(&self) -> *mut AVInputFormat {
+		self.as_ptr() as *mut _
+    }
+
+    #[cfg(feature = "ffmpeg_5_0")]
+    pub(crate) unsafe fn as_api_ptr(&self) -> *const AVInputFormat {
+		self.as_ptr()
+    }
 }
 
 impl Input {

--- a/src/format/io.rs
+++ b/src/format/io.rs
@@ -241,7 +241,7 @@ pub fn input_as(io: impl Read + Seek + 'static, format: format::Input) -> Result
 		(*ps).flags |= AVFMT_FLAG_CUSTOM_IO;
 		(*ps).pb = io.as_mut_ptr();
 
-		match avformat_open_input(&mut ps, ptr::null_mut(), format.as_ptr(), ptr::null_mut()) {
+		match avformat_open_input(&mut ps, ptr::null_mut(), format.as_api_ptr(), ptr::null_mut()) {
 			0 => match avformat_find_stream_info(ps, ptr::null_mut()) {
 				r if r >= 0 => Ok(context::Input::wrap_with(ps, io)),
 
@@ -261,7 +261,7 @@ pub fn output(io: impl Write + 'static, format: format::Output) -> Result<contex
 		let mut ps = ptr::null_mut();
 		let mut io = Io::output(io);
 
-		match avformat_alloc_output_context2(&mut ps, format.as_ptr(), ptr::null_mut(), ptr::null_mut()) {
+		match avformat_alloc_output_context2(&mut ps, format.as_api_ptr(), ptr::null_mut(), ptr::null_mut()) {
 			n if n >= 0 => {
 				(*ps).flags |= AVFMT_FLAG_CUSTOM_IO;
 				(*ps).pb = io.as_mut_ptr();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 #[cfg(feature = "format")]
 pub mod format;
 #[cfg(feature = "format")]
-pub use crate::format::chapter::{Chapter, ChapterMut};
+pub use crate::format::chapter::{Chapter, ChapterId, ChapterMut};
 #[cfg(feature = "format")]
 pub use crate::format::format::Format;
 #[cfg(feature = "format")]

--- a/src/software/resampling/extensions.rs
+++ b/src/software/resampling/extensions.rs
@@ -1,6 +1,7 @@
 use super::Context;
 use crate::{decoder, frame, util::format, ChannelLayout, Error};
 
+#[cfg(feature = "ffmpeg_6_0")]
 impl frame::Audio {
 	#[inline]
 	pub fn resampler(&self, format: format::Sample, channel_layout: ChannelLayout, rate: u32) -> Result<Context, Error> {
@@ -15,6 +16,7 @@ impl frame::Audio {
 	}
 }
 
+#[cfg(feature = "ffmpeg_6_0")]
 impl decoder::Audio {
 	#[inline]
 	pub fn resampler(&self, format: format::Sample, channel_layout: ChannelLayout, rate: u32) -> Result<Context, Error> {

--- a/src/util/channel_layout_pre6.rs
+++ b/src/util/channel_layout_pre6.rs
@@ -1,0 +1,83 @@
+use libc::c_ulonglong;
+
+use crate::ffi::*;
+
+bitflags! {
+	#[cfg_attr(feature = "serde", derive(serde_derive::Serialize, serde_derive::Deserialize))]
+	#[cfg_attr(feature = "serde", serde(crate = "serde_", rename_all = "kebab-case"))]
+	pub struct ChannelLayout: c_ulonglong {
+		const FRONT_LEFT            = AV_CH_FRONT_LEFT;
+		const FRONT_RIGHT           = AV_CH_FRONT_RIGHT;
+		const FRONT_CENTER          = AV_CH_FRONT_CENTER;
+		const LOW_FREQUENCY         = AV_CH_LOW_FREQUENCY;
+		const BACK_LEFT             = AV_CH_BACK_LEFT;
+		const BACK_RIGHT            = AV_CH_BACK_RIGHT;
+		const FRONT_LEFT_OF_CENTER  = AV_CH_FRONT_LEFT_OF_CENTER;
+		const FRONT_RIGHT_OF_CENTER = AV_CH_FRONT_RIGHT_OF_CENTER;
+		const BACK_CENTER           = AV_CH_BACK_CENTER;
+		const SIDE_LEFT             = AV_CH_SIDE_LEFT;
+		const SIDE_RIGHT            = AV_CH_SIDE_RIGHT;
+		const TOP_CENTER            = AV_CH_TOP_CENTER;
+		const TOP_FRONT_LEFT        = AV_CH_TOP_FRONT_LEFT;
+		const TOP_FRONT_CENTER      = AV_CH_TOP_FRONT_CENTER;
+		const TOP_FRONT_RIGHT       = AV_CH_TOP_FRONT_RIGHT;
+		const TOP_BACK_LEFT         = AV_CH_TOP_BACK_LEFT;
+		const TOP_BACK_CENTER       = AV_CH_TOP_BACK_CENTER;
+		const TOP_BACK_RIGHT        = AV_CH_TOP_BACK_RIGHT;
+		const STEREO_LEFT           = AV_CH_STEREO_LEFT;
+		const STEREO_RIGHT          = AV_CH_STEREO_RIGHT;
+		const WIDE_LEFT             = AV_CH_WIDE_LEFT;
+		const WIDE_RIGHT            = AV_CH_WIDE_RIGHT;
+		const SURROUND_DIRECT_LEFT  = AV_CH_SURROUND_DIRECT_LEFT;
+		const SURROUND_DIRECT_RIGHT = AV_CH_SURROUND_DIRECT_RIGHT;
+		const LOW_FREQUENCY_2       = AV_CH_LOW_FREQUENCY_2;
+		const TOP_SIDE_LEFT         = AV_CH_TOP_SIDE_LEFT;
+		const TOP_SIDE_RIGHT        = AV_CH_TOP_SIDE_RIGHT;
+		const BOTTOM_FRONT_CENTER   = AV_CH_BOTTOM_FRONT_CENTER;
+		const BOTTOM_FRONT_LEFT     = AV_CH_BOTTOM_FRONT_LEFT;
+		const BOTTOM_FRONT_RIGHT    = AV_CH_BOTTOM_FRONT_RIGHT;
+
+		const NATIVE             = AV_CH_LAYOUT_NATIVE;
+		const MONO               = AV_CH_LAYOUT_MONO;
+		const STEREO             = AV_CH_LAYOUT_STEREO;
+		const _2POINT1           = AV_CH_LAYOUT_2POINT1;
+		const _2_1               = AV_CH_LAYOUT_2_1;
+		const SURROUND           = AV_CH_LAYOUT_SURROUND;
+		const _3POINT1           = AV_CH_LAYOUT_3POINT1;
+		const _4POINT0           = AV_CH_LAYOUT_4POINT0;
+		const _4POINT1           = AV_CH_LAYOUT_4POINT1;
+		const _2_2               = AV_CH_LAYOUT_2_2;
+		const QUAD               = AV_CH_LAYOUT_QUAD;
+		const _5POINT0           = AV_CH_LAYOUT_5POINT0;
+		const _5POINT1           = AV_CH_LAYOUT_5POINT1;
+		const _5POINT0_BACK      = AV_CH_LAYOUT_5POINT0_BACK;
+		const _5POINT1_BACK      = AV_CH_LAYOUT_5POINT1_BACK;
+		const _6POINT0           = AV_CH_LAYOUT_6POINT0;
+		const _6POINT0_FRONT     = AV_CH_LAYOUT_6POINT0_FRONT;
+		const HEXAGONAL          = AV_CH_LAYOUT_HEXAGONAL;
+		const _6POINT1           = AV_CH_LAYOUT_6POINT1;
+		const _6POINT1_BACK      = AV_CH_LAYOUT_6POINT1_BACK;
+		const _6POINT1_FRONT     = AV_CH_LAYOUT_6POINT1_FRONT;
+		const _7POINT0           = AV_CH_LAYOUT_7POINT0;
+		const _7POINT0_FRONT     = AV_CH_LAYOUT_7POINT0_FRONT;
+		const _7POINT1           = AV_CH_LAYOUT_7POINT1;
+		const _7POINT1_WIDE      = AV_CH_LAYOUT_7POINT1_WIDE;
+		const _7POINT1_WIDE_BACK = AV_CH_LAYOUT_7POINT1_WIDE_BACK;
+		const OCTAGONAL          = AV_CH_LAYOUT_OCTAGONAL;
+		const HEXADECAGONAL      = AV_CH_LAYOUT_HEXADECAGONAL;
+		const STEREO_DOWNMIX     = AV_CH_LAYOUT_STEREO_DOWNMIX;
+	}
+}
+
+pub type Channel = i32;
+
+impl ChannelLayout {
+	#[inline]
+	pub fn channels(&self) -> i32 {
+		unsafe { av_get_channel_layout_nb_channels(self.bits()) }
+	}
+
+	pub fn default(number: i32) -> ChannelLayout {
+		unsafe { ChannelLayout::from_bits_truncate(av_get_default_channel_layout(number) as c_ulonglong) }
+	}
+}

--- a/src/util/frame/mod.rs
+++ b/src/util/frame/mod.rs
@@ -103,11 +103,13 @@ impl Frame {
 	}
 
 	#[inline]
+    #[cfg(feature = "ffmpeg_5_0")]
 	pub fn time_base(&self) -> Option<Rational> {
 		unsafe { Rational::from((*self.as_ptr()).time_base).non_zero() }
 	}
 
-	#[inline]
+    #[inline]
+    #[cfg(feature = "ffmpeg_5_0")]
 	pub fn set_time_base(&mut self, time_base: Option<impl Into<Rational>>) {
 		unsafe {
 			(*self.as_mut_ptr()).time_base = time_base.map(Into::into).unwrap_or(Rational::ZERO).into();
@@ -143,16 +145,26 @@ impl Frame {
 
 	#[inline]
 	pub fn duration(&self) -> Option<i64> {
-		unsafe {
-			match (*self.as_ptr()).duration {
-				0 => None,
-				d => Some(d),
-			}
-		}
+        #[cfg(not(feature = "ffmpeg_6_0"))]
+        let raw = unsafe { (*self.as_ptr()).pkt_duration };
+
+        #[cfg(feature = "ffmpeg_6_0")]
+        let raw = unsafe { (*self.as_ptr()).duration };
+
+         match raw {
+			 0 => None,
+			 d => Some(d),
+		 }
 	}
 
 	#[inline]
 	pub fn set_duration(&mut self, value: Option<i64>) {
+        #[cfg(feature = "ffmpeg_6_0")]
+		unsafe {
+			(*self.as_mut_ptr()).pkt_duration = value.unwrap_or(0);
+		}
+
+        #[cfg(feature = "ffmpeg_6_0")]
 		unsafe {
 			(*self.as_mut_ptr()).duration = value.unwrap_or(0);
 		}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,6 +1,5 @@
 #[macro_use]
 pub mod dictionary;
-pub mod channel_layout;
 pub mod chroma;
 pub mod color;
 pub mod error;
@@ -15,6 +14,9 @@ pub mod picture;
 pub mod range;
 pub mod rational;
 pub mod time;
+
+#[cfg_attr(not(feature = "ffmpeg_6_0"), path="channel_layout_pre6.rs")]
+pub mod channel_layout;
 
 #[cfg(feature = "log")]
 pub mod log;

--- a/src/util/option/mod.rs
+++ b/src/util/option/mod.rs
@@ -49,6 +49,7 @@ impl From<AVOptionType> for Type {
 			AV_OPT_TYPE_DURATION => Type::Duration,
 			AV_OPT_TYPE_COLOR => Type::Color,
 			AV_OPT_TYPE_CHANNEL_LAYOUT => Type::ChannelLayout,
+            #[cfg(feature = "ffmpeg_6_0")]
 			AV_OPT_TYPE_CHLAYOUT => Type::ChannelLayout,
 		}
 	}
@@ -76,7 +77,10 @@ impl Into<AVOptionType> for Type {
 			Type::VideoRate => AV_OPT_TYPE_VIDEO_RATE,
 			Type::Duration => AV_OPT_TYPE_DURATION,
 			Type::Color => AV_OPT_TYPE_COLOR,
+            #[cfg(feature = "ffmpeg_6_0")]
 			Type::ChannelLayout => AV_OPT_TYPE_CHLAYOUT,
+            #[cfg(not(feature = "ffmpeg_6_0"))]
+			Type::ChannelLayout => AV_OPT_TYPE_CHANNEL_LAYOUT,
 		}
 	}
 }

--- a/src/util/option/traits.rs
+++ b/src/util/option/traits.rs
@@ -128,17 +128,30 @@ pub trait Settable: Target {
 		}
 	}
 
+    #[cfg(feature = "ffmpeg_6_0")]
 	fn set_channel_layout(&mut self, name: &str, layout: ChannelLayout) -> Result<(), Error> {
 		unsafe {
 			let name = CString::new(name).unwrap();
-
 			check!(av_opt_set_chlayout(
 				self.as_mut_ptr(),
 				name.as_ptr(),
 				layout.as_ptr(),
 				AV_OPT_SEARCH_CHILDREN
 			))
-		}
+        }
+    }
+
+    #[cfg(not(feature = "ffmpeg_6_0"))]
+	fn set_channel_layout(&mut self, name: &str, layout: ChannelLayout) -> Result<(), Error> {
+		unsafe {
+			let name = CString::new(name).unwrap();
+            check!(av_opt_set_channel_layout(
+                self.as_mut_ptr(),
+				name.as_ptr(),
+				layout.bits() as i64,
+				AV_OPT_SEARCH_CHILDREN
+            ))
+        }
 	}
 }
 


### PR DESCRIPTION
I got a bit carried away here, hopefully it's of some use. :)

1. Expand CI to run on FFmpeg 6.1 with Ubuntu 24.04, as well as the exsiting FFmpeg 4.4 on Ubuntu 22.04.
2. Fix build errors against FFmpeg 4.4:

* Restore the pre-struct ChannelLayout support that was replaced in #173, implementation is selected based on feature flags.
* Add feature guards on some ChannelLayout functions so they work pre-6.0, disable some entirely where it looks like more work to support.
* Added a lot of workarounds for const-ification of pointer arguments in FFmpeg 5.0. Not sure if this is the best way around this, but seemed like an OK approach.
* Wrapped the chapter id in a type as it changed i32 -> i64 in 5.0
* Additional workarounds for things added or changed >=5.0

All in separate commits.

I was able to run the `transcode-x264` example under Ubuntu 22.04 (FFmpeg 4.4) but I have not done any additional testing. It's likely many other things are broken on earlier FFmpeg, but building is a first step to fixing. :grin: 